### PR TITLE
chore(devops): harden Vercel deploy workflow and add setup runbook

### DIFF
--- a/.github/workflows/deploy-api-vercel.yml
+++ b/.github/workflows/deploy-api-vercel.yml
@@ -13,9 +13,9 @@ on:
 
 jobs:
   deploy:
-    if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
     runs-on: ubuntu-latest
     env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
@@ -37,14 +37,42 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Preflight Vercel secrets
+        id: preflight
+        shell: bash
+        run: |
+          missing=0
+          if [[ -z "$VERCEL_TOKEN" ]]; then
+            echo "::notice::Missing GitHub secret VERCEL_TOKEN"
+            missing=1
+          fi
+          if [[ -z "$VERCEL_ORG_ID" ]]; then
+            echo "::notice::Missing GitHub secret VERCEL_ORG_ID"
+            missing=1
+          fi
+          if [[ -z "$VERCEL_PROJECT_ID" ]]; then
+            echo "::notice::Missing GitHub secret VERCEL_PROJECT_ID"
+            missing=1
+          fi
+
+          if [[ "$missing" -eq 1 ]]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping API deploy because required Vercel secrets are missing."
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Pull Vercel environment
+        if: steps.preflight.outputs.ready == 'true'
         working-directory: apps/api
-        run: pnpm dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Build Vercel artifact
+        if: steps.preflight.outputs.ready == 'true'
         working-directory: apps/api
-        run: pnpm dlx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy to Vercel
+        if: steps.preflight.outputs.ready == 'true'
         working-directory: apps/api
-        run: pnpm dlx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -47,3 +47,4 @@ Copiar `apps/api/.env.example` y completar:
   - `VERCEL_TOKEN`
   - `VERCEL_ORG_ID`
   - `VERCEL_PROJECT_ID`
+- Runbook de setup/verificacion: `docs/runbooks/vercel-api-deploy.md`.

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -64,6 +64,7 @@ pnpm build
 3. Push a `main` con cambios en `apps/api` o ejecutar workflow manual.
 4. Workflow: `.github/workflows/deploy-api-vercel.yml`.
    - Si faltan secrets, el job se marca como `skipped` (no falla CI).
+5. Runbook detallado: `docs/runbooks/vercel-api-deploy.md`.
 
 ## Notas
 - No hardcodear secretos en codigo ni en workflows.

--- a/docs/runbooks/vercel-api-deploy.md
+++ b/docs/runbooks/vercel-api-deploy.md
@@ -1,0 +1,68 @@
+# Runbook: Deploy API en Vercel
+
+## Objetivo
+Configurar y verificar el deploy serverless de `apps/api` hacia Vercel mediante GitHub Actions.
+
+## Secretos requeridos en GitHub
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+## 1) Obtener `VERCEL_TOKEN`
+En Vercel Dashboard:
+1. Ir a `Settings` -> `Tokens`.
+2. Crear un token nuevo con alcance a tu cuenta/equipo.
+3. Guardarlo en un lugar seguro (solo se muestra una vez).
+
+## 2) Obtener `VERCEL_ORG_ID` y `VERCEL_PROJECT_ID`
+Forma recomendada (deterministica con CLI):
+
+```bash
+pnpm dlx vercel login
+pnpm dlx vercel link --cwd apps/api
+```
+
+Luego leer archivo generado localmente (no versionado) `apps/api/.vercel/project.json`:
+- `orgId` -> `VERCEL_ORG_ID`
+- `projectId` -> `VERCEL_PROJECT_ID`
+
+## 3) Cargar secretos en GitHub
+Con GitHub CLI:
+
+```bash
+gh secret set VERCEL_TOKEN --body "<token>"
+gh secret set VERCEL_ORG_ID --body "<org-id>"
+gh secret set VERCEL_PROJECT_ID --body "<project-id>"
+```
+
+Verificar nombres cargados:
+
+```bash
+gh secret list
+```
+
+## 4) Variables de entorno del API en Vercel
+El workflow ejecuta `vercel pull --environment=production`, por lo que las variables deben existir en Vercel (entorno `Production`), por ejemplo:
+- `SUPABASE_URL`
+- `SUPABASE_SECRET_KEY`
+- `SUPABASE_PRODUCTS_TABLE`
+
+## 5) Verificar deploy end-to-end
+1. Lanzar workflow manual:
+```bash
+gh workflow run .github/workflows/deploy-api-vercel.yml --ref main
+```
+
+2. Revisar ejecucion:
+```bash
+gh run list --workflow .github/workflows/deploy-api-vercel.yml --limit 5
+gh run view <run-id>
+```
+
+3. Validar endpoint desplegado:
+```bash
+curl https://<tu-proyecto>.vercel.app/health
+```
+
+## Nota de hardening
+El workflow tiene preflight de secretos: si falta alguno, el job no falla por configuracion invalida y el deploy queda omitido con mensajes `notice`.


### PR DESCRIPTION
## Summary
- fix invalid GitHub Actions expression in Vercel deploy workflow (secrets in job-level if)
- add preflight step that validates required secrets and skips deploy safely when missing
- add detailed runbook for obtaining Vercel token/org/project identifiers
- link Vercel runbook from local-dev and API README

## Verification
- pnpm lint
- pnpm test
- pnpm build
- manual workflow dispatch on this branch: success with explicit notices when secrets are missing
  - run: https://github.com/RidelHI/ia-pm-development/actions/runs/21851055307

Refs #10