### PR TITLE
feat(api): add logical filters for products endpoint

### DIFF
--- a/apps/api/src/products/dto/products-query.dto.spec.ts
+++ b/apps/api/src/products/dto/products-query.dto.spec.ts
@@ -1,0 +1,52 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { ProductsQueryDto } from './products-query.dto';
+
+describe('ProductsQueryDto', () => {
+  it('transforms and validates optional fields', () => {
+    const dto = plainToInstance(ProductsQueryDto, {
+      q: '  apple  ',
+      sku: ' SKU-APPLE-001 ',
+      quantityMin: '1',
+      unitPriceMax: '500',
+    });
+    const errors = validateSync(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.q).toBe('apple');
+    expect(dto.sku).toBe('SKU-APPLE-001');
+    expect(dto.quantityMin).toBe(1);
+    expect(dto.unitPriceMax).toBe(500);
+  });
+
+  it('fails when a range max is lower than min', () => {
+    const dto = plainToInstance(ProductsQueryDto, {
+      quantityMin: 10,
+      quantityMax: 5,
+      unitPriceMin: 700,
+      unitPriceMax: 500,
+    });
+    const errors = validateSync(dto);
+
+    const constraints = errors.flatMap((error) => {
+      return Object.values(error.constraints ?? {});
+    });
+
+    expect(constraints).toContain(
+      'quantityMax must be greater than or equal to quantityMin',
+    );
+    expect(constraints).toContain(
+      'unitPriceMax must be greater than or equal to unitPriceMin',
+    );
+  });
+
+  it('fails when numeric filters are negative', () => {
+    const dto = plainToInstance(ProductsQueryDto, {
+      quantityMin: -1,
+      unitPriceMin: -10,
+    });
+    const errors = validateSync(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/products/dto/products-query.dto.ts
+++ b/apps/api/src/products/dto/products-query.dto.ts
@@ -7,10 +7,71 @@ import {
   Max,
   MaxLength,
   Min,
+  ValidationArguments,
+  ValidationOptions,
+  registerDecorator,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { PRODUCT_STATUSES, type ProductStatus } from '../product.types';
 import { trimOptionalString } from './transforms';
+
+function parseOptionalInt(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return Number.parseInt(value.toString(), 10);
+  }
+
+  if (typeof value !== 'string') {
+    return Number.NaN;
+  }
+
+  return Number.parseInt(value, 10);
+}
+
+function IsGreaterThanOrEqualField(
+  fieldName: string,
+  validationOptions?: ValidationOptions,
+) {
+  return (object: object, propertyName: string): void => {
+    registerDecorator({
+      name: 'isGreaterThanOrEqualField',
+      target: object.constructor,
+      propertyName,
+      constraints: [fieldName],
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, args: ValidationArguments): boolean {
+          if (value === undefined) {
+            return true;
+          }
+
+          const constraints = args.constraints as unknown[];
+          const relatedFieldName = constraints[0];
+
+          if (typeof relatedFieldName !== 'string') {
+            return false;
+          }
+
+          const object = args.object as Record<string, unknown>;
+          const relatedValue = object[relatedFieldName];
+
+          if (relatedValue === undefined) {
+            return true;
+          }
+
+          if (typeof value !== 'number' || typeof relatedValue !== 'number') {
+            return false;
+          }
+
+          return value >= relatedValue;
+        },
+      },
+    });
+  };
+}
 
 export class ProductsQueryDto {
   @ApiPropertyOptional({ maxLength: 120, example: 'apple' })
@@ -20,24 +81,75 @@ export class ProductsQueryDto {
   @MaxLength(120)
   q?: string;
 
+  @ApiPropertyOptional({ maxLength: 64, example: 'SKU-APPLE-001' })
+  @Transform(trimOptionalString)
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  sku?: string;
+
+  @ApiPropertyOptional({ maxLength: 120, example: 'Apple Box' })
+  @Transform(trimOptionalString)
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  name?: string;
+
+  @ApiPropertyOptional({ maxLength: 64, example: 'A-01' })
+  @Transform(trimOptionalString)
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  location?: string;
+
   @ApiPropertyOptional({ enum: PRODUCT_STATUSES, example: 'active' })
   @IsOptional()
   @IsIn(PRODUCT_STATUSES)
   status?: ProductStatus;
 
+  @ApiPropertyOptional({ minimum: 0, example: 1 })
+  @Transform(({ value }) => parseOptionalInt(value))
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  quantityMin?: number;
+
+  @ApiPropertyOptional({ minimum: 0, example: 100 })
+  @Transform(({ value }) => parseOptionalInt(value))
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @IsGreaterThanOrEqualField('quantityMin', {
+    message: 'quantityMax must be greater than or equal to quantityMin',
+  })
+  quantityMax?: number;
+
+  @ApiPropertyOptional({ minimum: 0, example: 100 })
+  @Transform(({ value }) => parseOptionalInt(value))
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  unitPriceMin?: number;
+
+  @ApiPropertyOptional({ minimum: 0, example: 5000 })
+  @Transform(({ value }) => parseOptionalInt(value))
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @IsGreaterThanOrEqualField('unitPriceMin', {
+    message: 'unitPriceMax must be greater than or equal to unitPriceMin',
+  })
+  unitPriceMax?: number;
+
   @ApiPropertyOptional({ minimum: 1, example: 1 })
-  @Transform(({ value }) =>
-    value === undefined ? undefined : Number.parseInt(String(value), 10),
-  )
+  @Transform(({ value }) => parseOptionalInt(value))
   @IsOptional()
   @IsInt()
   @Min(1)
   page?: number;
 
   @ApiPropertyOptional({ minimum: 1, maximum: 100, example: 20 })
-  @Transform(({ value }) =>
-    value === undefined ? undefined : Number.parseInt(String(value), 10),
-  )
+  @Transform(({ value }) => parseOptionalInt(value))
   @IsOptional()
   @IsInt()
   @Min(1)

--- a/apps/api/src/products/product.types.ts
+++ b/apps/api/src/products/product.types.ts
@@ -34,7 +34,14 @@ export interface UpdateProductInput {
 
 export interface ProductFilters {
   q?: string;
+  sku?: string;
+  name?: string;
+  location?: string;
   status?: ProductStatus;
+  quantityMin?: number;
+  quantityMax?: number;
+  unitPriceMin?: number;
+  unitPriceMax?: number;
   page?: number;
   limit?: number;
 }

--- a/apps/api/src/products/products.service.spec.ts
+++ b/apps/api/src/products/products.service.spec.ts
@@ -43,6 +43,35 @@ describe('ProductsService', () => {
     expect(firstPage.meta.totalPages).toBeGreaterThanOrEqual(2);
   });
 
+  it('filters products by explicit text fields', async () => {
+    const bySku = await service.findAll({ sku: 'APPLE' });
+    const byName = await service.findAll({ name: 'milk' });
+    const byLocation = await service.findAll({ location: 'B-03' });
+
+    expect(bySku.data).toHaveLength(1);
+    expect(bySku.data[0]?.sku).toBe('SKU-APPLE-001');
+    expect(byName.data).toHaveLength(1);
+    expect(byName.data[0]?.name).toBe('Milk Pack');
+    expect(byLocation.data).toHaveLength(1);
+    expect(byLocation.data[0]?.location).toBe('B-03');
+  });
+
+  it('filters products by numeric ranges', async () => {
+    const quantityRange = await service.findAll({
+      quantityMin: 20,
+      quantityMax: 50,
+    });
+    const priceRange = await service.findAll({
+      unitPriceMin: 500,
+      unitPriceMax: 700,
+    });
+
+    expect(quantityRange.data).toHaveLength(1);
+    expect(quantityRange.data[0]?.name).toBe('Apple Box');
+    expect(priceRange.data).toHaveLength(1);
+    expect(priceRange.data[0]?.name).toBe('Apple Box');
+  });
+
   it('creates a product', async () => {
     const product = await service.create({
       sku: 'SKU-BREAD-003',

--- a/apps/api/src/products/repositories/in-memory-products.repository.ts
+++ b/apps/api/src/products/repositories/in-memory-products.repository.ts
@@ -48,6 +48,9 @@ export class InMemoryProductsRepository implements ProductsRepository {
   findAll(filters: ProductFilters): Promise<PaginatedResult<Product>> {
     const products = Array.from(this.products.values());
     const normalizedQuery = filters.q?.trim().toLowerCase();
+    const normalizedSku = filters.sku?.trim().toLowerCase();
+    const normalizedName = filters.name?.trim().toLowerCase();
+    const normalizedLocation = filters.location?.trim().toLowerCase();
     const page = Math.max(
       filters.page ?? InMemoryProductsRepository.DEFAULT_PAGE,
       1,
@@ -68,7 +71,43 @@ export class InMemoryProductsRepository implements ProductsRepository {
           product.sku.toLowerCase().includes(normalizedQuery)
         : true;
 
-      return matchesStatus && matchesQuery;
+      const matchesSku = normalizedSku
+        ? product.sku.toLowerCase().includes(normalizedSku)
+        : true;
+      const matchesName = normalizedName
+        ? product.name.toLowerCase().includes(normalizedName)
+        : true;
+      const matchesLocation = normalizedLocation
+        ? (product.location ?? '').toLowerCase().includes(normalizedLocation)
+        : true;
+      const matchesQuantityMin =
+        filters.quantityMin !== undefined
+          ? product.quantity >= filters.quantityMin
+          : true;
+      const matchesQuantityMax =
+        filters.quantityMax !== undefined
+          ? product.quantity <= filters.quantityMax
+          : true;
+      const matchesPriceMin =
+        filters.unitPriceMin !== undefined
+          ? product.unitPriceCents >= filters.unitPriceMin
+          : true;
+      const matchesPriceMax =
+        filters.unitPriceMax !== undefined
+          ? product.unitPriceCents <= filters.unitPriceMax
+          : true;
+
+      return (
+        matchesStatus &&
+        matchesQuery &&
+        matchesSku &&
+        matchesName &&
+        matchesLocation &&
+        matchesQuantityMin &&
+        matchesQuantityMax &&
+        matchesPriceMin &&
+        matchesPriceMax
+      );
     });
     const total = filtered.length;
     const totalPages = total === 0 ? 0 : Math.ceil(total / limit);

--- a/apps/api/src/products/repositories/supabase-products.repository.spec.ts
+++ b/apps/api/src/products/repositories/supabase-products.repository.spec.ts
@@ -34,6 +34,9 @@ describe('SupabaseProductsRepository', () => {
     const query = {
       eq: jest.fn().mockReturnThis(),
       or: jest.fn().mockReturnThis(),
+      ilike: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
       range: jest.fn().mockReturnThis(),
       then,
     };
@@ -52,6 +55,13 @@ describe('SupabaseProductsRepository', () => {
 
     const result = await repository.findAll({
       q: 'milk,50%_()',
+      sku: 'SKU-1',
+      name: 'milk',
+      location: 'A-01',
+      quantityMin: 2,
+      quantityMax: 9,
+      unitPriceMin: 100,
+      unitPriceMax: 900,
       page: 2,
       limit: 5,
     });
@@ -62,5 +72,12 @@ describe('SupabaseProductsRepository', () => {
     expect(query.or).toHaveBeenCalledWith(
       'name.ilike.%milk\\,50\\%\\_\\(\\)%,sku.ilike.%milk\\,50\\%\\_\\(\\)%',
     );
+    expect(query.ilike).toHaveBeenCalledWith('sku', '%SKU-1%');
+    expect(query.ilike).toHaveBeenCalledWith('name', '%milk%');
+    expect(query.ilike).toHaveBeenCalledWith('location', '%A-01%');
+    expect(query.gte).toHaveBeenCalledWith('quantity', 2);
+    expect(query.lte).toHaveBeenCalledWith('quantity', 9);
+    expect(query.gte).toHaveBeenCalledWith('unitPriceCents', 100);
+    expect(query.lte).toHaveBeenCalledWith('unitPriceCents', 900);
   });
 });

--- a/apps/api/src/products/repositories/supabase-products.repository.ts
+++ b/apps/api/src/products/repositories/supabase-products.repository.ts
@@ -54,6 +54,37 @@ export class SupabaseProductsRepository implements ProductsRepository {
       query = query.or(`name.ilike.%${q}%,sku.ilike.%${q}%`);
     }
 
+    if (filters.sku?.trim()) {
+      const sku = this.escapeLike(filters.sku.trim());
+      query = query.ilike('sku', `%${sku}%`);
+    }
+
+    if (filters.name?.trim()) {
+      const name = this.escapeLike(filters.name.trim());
+      query = query.ilike('name', `%${name}%`);
+    }
+
+    if (filters.location?.trim()) {
+      const location = this.escapeLike(filters.location.trim());
+      query = query.ilike('location', `%${location}%`);
+    }
+
+    if (filters.quantityMin !== undefined) {
+      query = query.gte('quantity', filters.quantityMin);
+    }
+
+    if (filters.quantityMax !== undefined) {
+      query = query.lte('quantity', filters.quantityMax);
+    }
+
+    if (filters.unitPriceMin !== undefined) {
+      query = query.gte('unitPriceCents', filters.unitPriceMin);
+    }
+
+    if (filters.unitPriceMax !== undefined) {
+      query = query.lte('unitPriceCents', filters.unitPriceMax);
+    }
+
     query = query.range(from, to);
 
     const result = (await query) as QueryResultWithCount<Product[]>;


### PR DESCRIPTION
## Linked Issue
Closes #14

## Scope
- Extend product filtering in `GET /v1/products` with logical fields.
- Keep existing pagination and current filters.
- Cover new behavior with tests.

## Changes
- Added optional filters: `sku`, `name`, `location`, `quantityMin`, `quantityMax`, `unitPriceMin`, `unitPriceMax`.
- Added range validation:
  - `quantityMax >= quantityMin`
  - `unitPriceMax >= unitPriceMin`
- Implemented filters in:
  - `InMemoryProductsRepository`
  - `SupabaseProductsRepository`
- Added/updated tests for DTO validation and filtering behavior.

## Validation
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`

## Risks / Notes
- No breaking API contract changes; only optional query parameters were added.