### PR TITLE
chore: enforce github flow guardrails and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/**'
-      - 'libs/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.github/workflows/ci.yml'
   push:
     branches: [main]
-    paths:
-      - 'apps/**'
-      - 'libs/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,16 +11,18 @@ Operate as a professional software delivery agent for a monorepo with:
 1. Enforce `agent-first` process from `docs/ai/agent-operating-model.md`.
 2. Require an issue with exactly one `agent:*` label before implementation.
 3. Keep 1 issue = 1 branch = 1 PR.
-4. Use `pnpm` only. Do not use `npm` or `yarn`.
-5. Run and report:
+4. Follow Git branching strategy from `docs/runbooks/git-branching-model.md`.
+5. Use `pnpm` only. Do not use `npm` or `yarn`.
+6. Run and report:
    - `pnpm lint`
    - `pnpm test`
    - `pnpm build`
-6. Require `Closes #<issue_number>` in PR body.
-7. Keep PR scope aligned to issue acceptance criteria.
+7. Require `Closes #<issue_number>` in PR body.
+8. Keep PR scope aligned to issue acceptance criteria.
 
 ## Source of Truth
 - Workflow rules: `docs/runbooks/github-project-workflow.md`
+- Git strategy: `docs/runbooks/git-branching-model.md`
 - Operating model: `docs/ai/agent-operating-model.md`
 - Backlog conventions: `docs/planning/github-project-backlog.md`
 - Local operation: `docs/runbooks/local-dev.md`

--- a/docs/ai/agent-operating-model.md
+++ b/docs/ai/agent-operating-model.md
@@ -17,6 +17,7 @@ No se asume ejecucion paralela de cinco agentes independientes.
 2. Toda tarea nace como issue y debe tener exactamente un label `agent:*`.
 3. Cada cambio tecnico se entrega por PR pequena enlazada con `Closes #<issue_number>`.
 4. CI bloquea merge si falta issue enlazada o si la issue no tiene ownership por agente.
+5. La estrategia de ramas es `GitHub Flow` con ramas cortas segun `docs/runbooks/git-branching-model.md`.
 
 ## Taxonomia de agentes
 | Label | Rol | Responsabilidad principal | Entregables obligatorios |
@@ -82,6 +83,8 @@ Usar estos artefactos para repetir procesos con consistencia:
   - `docs/ai/workflows/new-feature.md`
   - `docs/ai/workflows/review-pr.md`
   - `docs/ai/workflows/deploy.md`
+- Git strategy:
+  - `docs/runbooks/git-branching-model.md`
 - Prompt templates:
   - `docs/ai/prompts/feature-spec-prompt.md`
   - `docs/ai/prompts/audit-prompt.md`

--- a/docs/runbooks/git-branching-model.md
+++ b/docs/runbooks/git-branching-model.md
@@ -1,0 +1,102 @@
+# Runbook: GitHub Flow Professional
+
+## Objetivo
+Definir un flujo unico y simple para evitar confusiones en Git/GitHub y mantener trazabilidad completa con Issues + PR.
+
+## Estrategia adoptada
+Este repo usa `GitHub Flow` (trunk-based pragmatica), no `GitFlow` clasico.
+
+Reglas base:
+1. `main` es la rama estable y protegida.
+2. Todo cambio sale desde `main` actualizada.
+3. 1 issue = 1 branch = 1 PR.
+4. Ramas cortas (ideal: menos de 2 dias).
+5. Merge por `squash` y borrado automatico de rama al merge.
+6. Releases por tags/versionado, no por ramas largas de release.
+
+Convencion de ramas:
+- `feature/<slug>`
+- `fix/<slug>`
+- `chore/<slug>`
+
+## Preparacion local (una vez por repo)
+```bash
+git config --local pull.ff only
+git config --local fetch.prune true
+git config --local rerere.enabled true
+```
+
+## Flujo estandar por caso
+
+### Caso 1: Nueva funcionalidad
+```bash
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git switch -c feature/<slug>
+```
+
+Implementar cambios pequenos y commitear de forma clara:
+```bash
+git add .
+git commit -m "feat(api): <resumen>"
+git push -u origin feature/<slug>
+```
+
+Abrir PR enlazando issue:
+- `Closes #<issue_number>`
+
+### Caso 2: Bug normal (no urgente)
+Mismo flujo que feature, pero usando `fix/<slug>`.
+
+### Caso 3: Hotfix urgente en produccion
+1. Crear issue de hotfix.
+2. Salir desde `main` actualizada:
+```bash
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git switch -c fix/<slug-hotfix>
+```
+3. Abrir PR pequena, validar CI y merge prioritario.
+4. Verificar deploy/smoke test.
+
+### Caso 4: Tu rama quedo atras y quieres evitar conflictos
+```bash
+git fetch origin
+git switch <tu-rama>
+git merge origin/main
+```
+
+Si hay conflictos:
+1. Resolver archivos en conflicto.
+2. `git add <archivo>`
+3. `git commit`
+4. `git push`
+
+Nota: En este repo preferimos `merge origin/main` en ramas de trabajo para evitar reescritura de historia compartida.
+
+### Caso 5: Conflictos detectados en PR
+Aplicar el Caso 4 en la rama del PR y volver a ejecutar CI.
+
+### Caso 6: Necesitas deshacer algo ya mergeado
+No reescribir historia en `main`.
+```bash
+git switch main
+git pull --ff-only origin main
+git revert <sha>
+git push origin main
+```
+
+## Reglas anti-caos
+1. No push directo a `main`.
+2. No mezclar multiples issues en un mismo PR.
+3. No trabajar en ramas de otros autores.
+4. Si una rama crece demasiado, dividir en mas issues/PR.
+5. Si el contexto cambio fuerte, cerrar rama y crear una nueva desde `main`.
+
+## Checklist rapido antes de abrir PR
+1. Rama correcta (`feature/`, `fix/` o `chore/`).
+2. Issue enlazada en descripcion (`Closes #...`).
+3. Cambios acotados al scope.
+4. `pnpm lint`, `pnpm test`, `pnpm build` en verde.

--- a/docs/runbooks/github-pr-flow.md
+++ b/docs/runbooks/github-pr-flow.md
@@ -1,62 +1,52 @@
-# Runbook: GitHub Remote + PR Flow
+# Runbook: GitHub PR Guardrails
 
 ## Objetivo
-Dejar el repo listo para trabajo por PR con `main` protegida y convención de ramas.
+Configurar GitHub para que el flujo por PR se cumpla de forma automatica y consistente.
 
 ## Prerrequisitos
 - `gh` autenticado (`gh auth status`).
-- Repo local con commit inicial.
+- Permisos de admin sobre el repo.
 
-## 1) Crear/conectar remoto
+## 1) Configurar estrategia de merge del repo
+Para mantener historia limpia y simple:
 ```bash
-gh repo create <owner>/<repo> --private --source=. --remote=origin
-git branch main
-git push -u origin main
-git push -u origin feature/<slug>
+gh repo edit <owner>/<repo> \
+  --delete-branch-on-merge \
+  --enable-squash-merge \
+  --enable-merge-commit=false \
+  --enable-rebase-merge=false
 ```
 
-Si ya existe el repo remoto:
-```bash
-git remote add origin https://github.com/<owner>/<repo>.git
-git push -u origin main
-```
-
-## 2) Protección de `main`
-En cuentas free, branch protection completa requiere repo público.
-
-Opciones:
-1. Mantener privado y usar GitHub Pro.
-2. Hacer público el repo para mantener costo cero (recomendado en este proyecto de aprendizaje).
-
-```bash
-gh repo edit <owner>/<repo> --visibility public
-```
-
-Aplicar protección:
+## 2) Proteger `main`
+Aplicar proteccion (ajustar owner/repo segun corresponda):
 ```bash
 gh api --method PUT repos/<owner>/<repo>/branches/main/protection --input ./main-protection.json
 ```
 
-Payload recomendado (`main-protection.json`):
+Payload base recomendado (`main-protection.json`):
 - `required_status_checks.strict = true`
 - `required_status_checks.contexts = ["quality"]`
-- `required_pull_request_reviews.required_approving_review_count = 1`
-- `dismiss_stale_reviews = true`
+- `required_pull_request_reviews.dismiss_stale_reviews = true`
+- `required_pull_request_reviews.required_approving_review_count = 0` (modo solo)
 - `required_conversation_resolution = true`
+- `required_linear_history = true`
 - `allow_force_pushes = false`
 - `allow_deletions = false`
 - `enforce_admins = true`
 
-## 3) Branch rules
-La convención se valida en CI (`.github/workflows/ci.yml`) en PR:
+Modo equipo:
+- Subir `required_approving_review_count` a `1`.
+
+## 3) Convencion de ramas
+La convencion se valida en CI (`.github/workflows/ci.yml`):
 - `feature/<slug>`
 - `fix/<slug>`
 - `chore/<slug>`
 
 Si la rama no cumple, CI falla y bloquea merge por el check requerido `quality`.
 
-## 4) Verificación
+## 4) Verificacion
 ```bash
-gh repo view <owner>/<repo> --json url,visibility,defaultBranchRef
+gh repo view <owner>/<repo> --json defaultBranchRef,deleteBranchOnMerge,mergeCommitAllowed,rebaseMergeAllowed,squashMergeAllowed
 gh api repos/<owner>/<repo>/branches/main/protection
 ```

--- a/docs/runbooks/github-project-workflow.md
+++ b/docs/runbooks/github-project-workflow.md
@@ -48,6 +48,7 @@ gh pr list --state open --limit 20
 
 ## Referencia
 - Modelo completo de roles y reglas: `docs/ai/agent-operating-model.md`
+- Estrategia de ramas por caso: `docs/runbooks/git-branching-model.md`
 - Instrucciones persistentes del agente: `AGENTS.md`
 - Workflows operativos: `docs/ai/workflows/`
 - Prompt templates: `docs/ai/prompts/`


### PR DESCRIPTION
## Linked Issue\n- Closes #18\n- [x] Linked issue has exactly one gent:* label\n\n## Scope\n- [x] This PR implements only the issue scope and acceptance criteria\n- [x] Issue status moved to In Review in GitHub Project\n\n## Changes\n- Added docs/runbooks/git-branching-model.md with standard GitHub Flow by case\n- Updated docs/runbooks/github-pr-flow.md with PR guardrails and merge strategy\n- Updated docs/runbooks/github-project-workflow.md references\n- Updated docs/ai/agent-operating-model.md to pin branching strategy\n- Updated AGENTS.md to require new git strategy runbook\n- Updated .github/workflows/ci.yml to run on all PRs to main\n\n## Validation\n- [x] pnpm lint\n- [x] pnpm test\n- [x] pnpm build\n\n## Risks / Notes\n- CI runtime may increase slightly because PR checks now run even for docs-only PRs\n