### PR TITLE
FE-04: flujo completo register/login y listado autenticado

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -11,10 +11,13 @@ Estructura base feature-first en `apps/web/src/app`:
   - `auth.interceptor.ts`: agrega `Authorization: Bearer <token>` cuando existe sesión.
 - `core/guards/`
   - `auth.guard.ts`: guard funcional para rutas privadas.
+  - `guest.guard.ts`: redirecciona usuarios autenticados fuera de login/register.
 - `features/auth/pages/`
   - `login.page.ts`, `register.page.ts`.
 - `features/products/pages/`
   - `products.page.ts` protegida por guard.
+- `features/products/data/`
+  - `products-api.service.ts`: integración tipada de `GET /v1/products`.
 
 ## Routing
 

--- a/apps/web/src/app/app.routes.ts
+++ b/apps/web/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { authGuard } from './core/guards/auth.guard';
+import { guestGuard } from './core/guards/guest.guard';
 
 export const routes: Routes = [
   {
@@ -9,11 +10,13 @@ export const routes: Routes = [
   },
   {
     path: 'login',
+    canActivate: [guestGuard],
     loadComponent: () =>
       import('./features/auth/pages/login.page').then((m) => m.LoginPageComponent),
   },
   {
     path: 'register',
+    canActivate: [guestGuard],
     loadComponent: () =>
       import('./features/auth/pages/register.page').then(
         (m) => m.RegisterPageComponent,

--- a/apps/web/src/app/core/auth/auth-api.service.spec.ts
+++ b/apps/web/src/app/core/auth/auth-api.service.spec.ts
@@ -1,0 +1,85 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { API_BASE_URL } from '../config/api-base-url.token';
+import { AuthApiService } from './auth-api.service';
+import { AuthStore } from './auth.store';
+
+describe('AuthApiService', () => {
+  let service: AuthApiService;
+  let httpController: HttpTestingController;
+  let authStore: AuthStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: API_BASE_URL,
+          useValue: 'http://localhost:3000/v1',
+        },
+      ],
+    });
+
+    service = TestBed.inject(AuthApiService);
+    httpController = TestBed.inject(HttpTestingController);
+    authStore = TestBed.inject(AuthStore);
+    authStore.clearSession();
+  });
+
+  afterEach(() => {
+    httpController.verify();
+  });
+
+  it('calls register endpoint', async () => {
+    const responsePromise = firstValueFrom(
+      service.register({
+        username: 'warehouse.user',
+        password: 'StrongPassword123!',
+      }),
+    );
+    const request = httpController.expectOne(
+      'http://localhost:3000/v1/auth/register',
+    );
+
+    expect(request.request.method).toBe('POST');
+    request.flush({
+      id: 'usr_01',
+      username: 'warehouse.user',
+      role: 'user',
+      createdAt: '2026-02-12T00:00:00.000Z',
+      updatedAt: '2026-02-12T00:00:00.000Z',
+    });
+
+    const response = await responsePromise;
+    expect(response.username).toBe('warehouse.user');
+  });
+
+  it('stores session on successful login', async () => {
+    const responsePromise = firstValueFrom(
+      service.login({
+        username: 'warehouse.user',
+        password: 'StrongPassword123!',
+      }),
+    );
+    const request = httpController.expectOne(
+      'http://localhost:3000/v1/auth/token',
+    );
+
+    expect(request.request.method).toBe('POST');
+    request.flush({
+      accessToken: 'token-123',
+      tokenType: 'Bearer',
+      expiresInSeconds: 900,
+    });
+
+    await responsePromise;
+    expect(authStore.isAuthenticated()).toBe(true);
+    expect(authStore.accessToken()).toBe('token-123');
+  });
+});

--- a/apps/web/src/app/core/guards/guest.guard.spec.ts
+++ b/apps/web/src/app/core/guards/guest.guard.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  provideRouter,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { AuthStore } from '../auth/auth.store';
+import { guestGuard } from './guest.guard';
+
+describe('guestGuard', () => {
+  let isAuthenticated = false;
+
+  beforeEach(() => {
+    isAuthenticated = false;
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthStore,
+          useValue: {
+            isAuthenticated: () => isAuthenticated,
+          },
+        },
+      ],
+    });
+  });
+
+  it('allows access for guests', () => {
+    const result = TestBed.runInInjectionContext(() =>
+      guestGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('redirects authenticated users to /products', () => {
+    isAuthenticated = true;
+
+    const result = TestBed.runInInjectionContext(() =>
+      guestGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+    expect(result instanceof UrlTree).toBe(true);
+    const router = TestBed.inject(Router);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/products');
+  });
+});

--- a/apps/web/src/app/core/guards/guest.guard.ts
+++ b/apps/web/src/app/core/guards/guest.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthStore } from '../auth/auth.store';
+
+export const guestGuard: CanActivateFn = () => {
+  const authStore = inject(AuthStore);
+  const router = inject(Router);
+
+  if (!authStore.isAuthenticated()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/products']);
+};

--- a/apps/web/src/app/features/products/data/products-api.service.spec.ts
+++ b/apps/web/src/app/features/products/data/products-api.service.spec.ts
@@ -1,0 +1,77 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { API_BASE_URL } from '../../../core/config/api-base-url.token';
+import { ProductsApiService } from './products-api.service';
+
+describe('ProductsApiService', () => {
+  let service: ProductsApiService;
+  let httpController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: API_BASE_URL,
+          useValue: 'http://localhost:3000/v1',
+        },
+      ],
+    });
+
+    service = TestBed.inject(ProductsApiService);
+    httpController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpController.verify();
+  });
+
+  it('requests products with default pagination', async () => {
+    const responsePromise = firstValueFrom(service.listProducts());
+    const request = httpController.expectOne(
+      (req) =>
+        req.url === 'http://localhost:3000/v1/products' &&
+        req.params.get('page') === '1' &&
+        req.params.get('limit') === '20',
+    );
+
+    expect(request.request.method).toBe('GET');
+    request.flush({
+      data: [],
+      meta: {
+        page: 1,
+        limit: 20,
+        total: 0,
+        totalPages: 0,
+      },
+    });
+
+    const response = await responsePromise;
+    expect(response.data).toEqual([]);
+  });
+
+  it('includes query param when search text is provided', () => {
+    service.listProducts('sku-001').subscribe();
+    const request = httpController.expectOne(
+      (req) =>
+        req.url === 'http://localhost:3000/v1/products' &&
+        req.params.get('q') === 'sku-001',
+    );
+
+    request.flush({
+      data: [],
+      meta: {
+        page: 1,
+        limit: 20,
+        total: 0,
+        totalPages: 0,
+      },
+    });
+  });
+});

--- a/apps/web/src/app/features/products/data/products-api.service.ts
+++ b/apps/web/src/app/features/products/data/products-api.service.ts
@@ -1,0 +1,28 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../../../core/config/api-base-url.token';
+import type { PaginatedProductsResponse } from './products.models';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProductsApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseApiUrl = inject(API_BASE_URL);
+
+  listProducts(query?: string): Observable<PaginatedProductsResponse> {
+    let params = new HttpParams().set('page', '1').set('limit', '20');
+
+    if (query?.trim()) {
+      params = params.set('q', query.trim());
+    }
+
+    return this.http.get<PaginatedProductsResponse>(
+      `${this.baseApiUrl}/products`,
+      {
+        params,
+      },
+    );
+  }
+}

--- a/apps/web/src/app/features/products/data/products.models.ts
+++ b/apps/web/src/app/features/products/data/products.models.ts
@@ -1,0 +1,21 @@
+export interface Product {
+  id: string;
+  sku: string;
+  name: string;
+  quantity: number;
+  unitPriceCents: number;
+  status: 'active' | 'inactive';
+  location: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PaginatedProductsResponse {
+  data: Product[];
+  meta: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}

--- a/apps/web/src/app/features/products/pages/products.page.ts
+++ b/apps/web/src/app/features/products/pages/products.page.ts
@@ -1,16 +1,16 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { CurrencyPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
 import { AuthStore } from '../../../core/auth/auth.store';
-
-interface ProductPreview {
-  id: string;
-  sku: string;
-  name: string;
-  status: 'active' | 'inactive';
-}
+import { ProductsApiService } from '../data/products-api.service';
+import type { Product } from '../data/products.models';
 
 @Component({
   selector: 'app-products-page',
+  imports: [FormsModule, CurrencyPipe],
   template: `
     <main class="min-h-screen bg-shell p-6 md:p-10">
       <section class="mx-auto max-w-5xl space-y-4">
@@ -20,7 +20,9 @@ interface ProductPreview {
               Protected Route
             </p>
             <h1 class="text-2xl font-semibold text-slate-900">Productos</h1>
-            <p class="text-sm text-slate-600">Acceso habilitado para token válido.</p>
+            <p class="text-sm text-slate-600">
+              Integración activa con <code>GET /v1/products</code>.
+            </p>
           </div>
           <button
             (click)="logout()"
@@ -31,20 +33,63 @@ interface ProductPreview {
           </button>
         </header>
 
-        <section class="grid gap-3 md:grid-cols-2">
-          @for (product of products(); track product.id) {
-            <article class="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm">
-              <p class="text-xs font-semibold uppercase tracking-[0.15em] text-cyan-700">
-                {{ product.sku }}
-              </p>
-              <h2 class="mt-1 text-lg font-semibold text-slate-900">{{ product.name }}</h2>
-              <p class="mt-2 text-sm text-slate-600">
-                Estado:
-                <span class="font-semibold text-slate-800">{{ product.status }}</span>
-              </p>
-            </article>
-          }
+        <section class="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm">
+          <form class="flex flex-wrap gap-3" (ngSubmit)="loadProducts()">
+            <input
+              [(ngModel)]="query"
+              class="min-w-64 flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none ring-cyan-400 focus:ring-2"
+              name="query"
+              placeholder="Buscar por nombre o SKU"
+              type="text"
+            />
+            <button
+              [disabled]="isLoading()"
+              class="rounded-lg bg-cyan-700 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-600 disabled:cursor-not-allowed disabled:opacity-60"
+              type="submit"
+            >
+              @if (isLoading()) { Cargando... } @else { Buscar }
+            </button>
+          </form>
         </section>
+
+        @if (errorMessage()) {
+          <section class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            {{ errorMessage() }}
+          </section>
+        }
+
+        @if (!isLoading() && products().length === 0 && !errorMessage()) {
+          <section class="rounded-2xl border border-stone-200 bg-white px-4 py-8 text-center text-sm text-slate-600 shadow-sm">
+            No hay productos para mostrar con los filtros actuales.
+          </section>
+        }
+
+        @if (products().length > 0) {
+          <section class="grid gap-3 md:grid-cols-2">
+            @for (product of products(); track product.id) {
+              <article class="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm">
+                <p class="text-xs font-semibold uppercase tracking-[0.15em] text-cyan-700">
+                  {{ product.sku }}
+                </p>
+                <h2 class="mt-1 text-lg font-semibold text-slate-900">{{ product.name }}</h2>
+                <p class="mt-2 text-sm text-slate-600">
+                  Cantidad:
+                  <span class="font-semibold text-slate-800">{{ product.quantity }}</span>
+                </p>
+                <p class="text-sm text-slate-600">
+                  Precio:
+                  <span class="font-semibold text-slate-800">{{
+                    product.unitPriceCents / 100 | currency: 'USD'
+                  }}</span>
+                </p>
+                <p class="text-sm text-slate-600">
+                  Estado:
+                  <span class="font-semibold text-slate-800">{{ product.status }}</span>
+                </p>
+              </article>
+            }
+          </section>
+        }
       </section>
     </main>
   `,
@@ -53,19 +98,52 @@ interface ProductPreview {
 export class ProductsPageComponent {
   private readonly authStore = inject(AuthStore);
   private readonly router = inject(Router);
-  private readonly fallbackProducts = signal<ProductPreview[]>([
-    {
-      id: 'preview-1',
-      sku: 'SKU-PREVIEW-001',
-      name: 'Producto de ejemplo',
-      status: 'active',
-    },
-  ]);
+  private readonly productsApiService = inject(ProductsApiService);
+  private readonly productsState = signal<Product[]>([]);
 
-  readonly products = computed(() => this.fallbackProducts());
+  readonly products = computed(() => this.productsState());
+  readonly isLoading = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+  query = '';
+
+  constructor() {
+    void this.loadProducts();
+  }
+
+  async loadProducts(): Promise<void> {
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+
+    try {
+      const response = await firstValueFrom(
+        this.productsApiService.listProducts(this.query),
+      );
+      this.productsState.set(response.data);
+    } catch (error) {
+      this.errorMessage.set(this.resolveProductsError(error));
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
 
   logout(): void {
     this.authStore.clearSession();
     void this.router.navigate(['/login']);
+  }
+
+  private resolveProductsError(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      if (error.status === 401) {
+        this.authStore.clearSession();
+        void this.router.navigate(['/login']);
+        return 'Tu sesión expiró. Vuelve a iniciar sesión.';
+      }
+
+      if (error.status === 403) {
+        return 'No tienes permisos para consultar productos.';
+      }
+    }
+
+    return 'No se pudo cargar la lista de productos.';
   }
 }


### PR DESCRIPTION
## Summary
- complete register/login UX flow with actionable API error messages (400/401/409)
- add guest guard for session-based redirections (`/login` and `/register` redirect to `/products` when already authenticated)
- replace products mock data with real API integration via `ProductsApiService` (`GET /v1/products`)
- add loading/empty/error states in products page and session-expired handling for 401 responses
- add/expand unit tests for critical services and guards (`auth-api`, `products-api`, `guestGuard`)
- update frontend architecture docs in `apps/web/README.md`

## Validation
- `pnpm --filter web lint`
- `pnpm --filter web test`
- `pnpm --filter web build`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Notes
- Auth session remains persisted via `AuthStore` and consumed by interceptor/guards.
- Products page now calls backend API and shows explicit feedback states.

Closes #23