### PR TITLE
test(qa): quality gate for register-login-products flow

### DIFF
--- a/apps/web/src/app/features/auth/pages/login.page.spec.ts
+++ b/apps/web/src/app/features/auth/pages/login.page.spec.ts
@@ -1,0 +1,80 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+import { AuthApiService } from '../../../core/auth/auth-api.service';
+import { LoginPageComponent } from './login.page';
+
+describe('LoginPageComponent', () => {
+  let loginImplementation: (
+    credentials: Readonly<{ username: string; password: string }>,
+  ) => Observable<unknown>;
+  let loginCalls: { username: string; password: string }[];
+  const authApiServiceMock = {
+    login(credentials: Readonly<{ username: string; password: string }>) {
+      loginCalls.push({ ...credentials });
+      return loginImplementation(credentials);
+    },
+  };
+
+  beforeEach(async () => {
+    loginCalls = [];
+    loginImplementation = () =>
+      of({
+        accessToken: 'token-123',
+        tokenType: 'Bearer',
+        expiresInSeconds: 900,
+      });
+    await TestBed.configureTestingModule({
+      imports: [LoginPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthApiService,
+          useValue: authApiServiceMock,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('submits valid credentials and navigates to products', async () => {
+    const fixture = TestBed.createComponent(LoginPageComponent);
+    const component = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    const navigateCalls: unknown[] = [];
+    router.navigate = ((...args: unknown[]) => {
+      navigateCalls.push(args);
+      return Promise.resolve(true);
+    }) as Router['navigate'];
+
+    component.form.setValue({
+      username: 'warehouse.user',
+      password: 'StrongPassword123!',
+    });
+    await component.submit();
+
+    expect(loginCalls).toEqual([
+      {
+        username: 'warehouse.user',
+        password: 'StrongPassword123!',
+      },
+    ]);
+    expect(navigateCalls).toEqual([[['/products']]]);
+    expect(component.errorMessage()).toBeNull();
+  });
+
+  it('shows actionable message on 401 response', async () => {
+    loginImplementation = () =>
+      throwError(() => new HttpErrorResponse({ status: 401 }));
+    const fixture = TestBed.createComponent(LoginPageComponent);
+    const component = fixture.componentInstance;
+
+    component.form.setValue({
+      username: 'warehouse.user',
+      password: 'WrongPassword123!',
+    });
+    await component.submit();
+
+    expect(component.errorMessage()).toContain('Credenciales inválidas');
+  });
+});

--- a/apps/web/src/app/features/products/pages/products.page.spec.ts
+++ b/apps/web/src/app/features/products/pages/products.page.spec.ts
@@ -1,0 +1,111 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+import { AuthStore } from '../../../core/auth/auth.store';
+import { ProductsApiService } from '../data/products-api.service';
+import { ProductsPageComponent } from './products.page';
+import type { PaginatedProductsResponse } from '../data/products.models';
+
+describe('ProductsPageComponent', () => {
+  let listProductsImplementation: (
+    query?: string,
+  ) => Observable<PaginatedProductsResponse>;
+  let listProductsQueries: string[];
+  let clearSessionCalls: number;
+
+  const productsApiServiceMock = {
+    listProducts(query = '') {
+      listProductsQueries.push(query);
+      return listProductsImplementation(query);
+    },
+  };
+  const authStoreMock = {
+    clearSession() {
+      clearSessionCalls += 1;
+    },
+  };
+
+  beforeEach(async () => {
+    listProductsQueries = [];
+    clearSessionCalls = 0;
+    listProductsImplementation = () =>
+      of({
+        data: [],
+        meta: {
+          page: 1,
+          limit: 20,
+          total: 0,
+          totalPages: 0,
+        },
+      });
+    await TestBed.configureTestingModule({
+      imports: [ProductsPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ProductsApiService,
+          useValue: productsApiServiceMock,
+        },
+        {
+          provide: AuthStore,
+          useValue: authStoreMock,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('loads products from API on init', async () => {
+    listProductsImplementation = () =>
+      of({
+        data: [
+          {
+            id: 'prod-01',
+            sku: 'SKU-01',
+            name: 'Product 01',
+            quantity: 2,
+            unitPriceCents: 1500,
+            status: 'active',
+            location: 'A-01',
+            createdAt: '2026-02-12T00:00:00.000Z',
+            updatedAt: '2026-02-12T00:00:00.000Z',
+          },
+        ],
+        meta: {
+          page: 1,
+          limit: 20,
+          total: 1,
+          totalPages: 1,
+        },
+      });
+    const fixture = TestBed.createComponent(ProductsPageComponent);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const component = fixture.componentInstance;
+    expect(listProductsQueries).toEqual(['']);
+    expect(component.products().length).toBe(1);
+    expect(component.errorMessage()).toBeNull();
+  });
+
+  it('clears session and redirects on 401 list error', async () => {
+    listProductsImplementation = () =>
+      throwError(() => new HttpErrorResponse({ status: 401 }));
+    const fixture = TestBed.createComponent(ProductsPageComponent);
+    const router = TestBed.inject(Router);
+    const navigateCalls: unknown[] = [];
+    router.navigate = ((...args: unknown[]) => {
+      navigateCalls.push(args);
+      return Promise.resolve(true);
+    }) as Router['navigate'];
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const component = fixture.componentInstance;
+    expect(clearSessionCalls).toBe(1);
+    expect(navigateCalls).toEqual([[['/login']]]);
+    expect(component.errorMessage()).toContain('sesión expiró');
+  });
+});

--- a/docs/qa/qa-01-auth-flow-quality-gate.md
+++ b/docs/qa/qa-01-auth-flow-quality-gate.md
@@ -1,0 +1,50 @@
+# QA-01 Quality Gate: register-login-products
+
+Issue: `#24`  
+Role: `agent:qa`  
+Branch: `feature/qa-01-auth-flow-quality-gate`
+
+## Quality Decision
+Status: **PASS (Ready for review)**
+
+The auth flow is covered in backend and frontend for happy path and rejection path, with local validation evidence for lint, test, and build.
+
+## Risk-Based Test Matrix
+| Risk area | Scenario | Expected result | Evidence |
+| --- | --- | --- | --- |
+| Registration contract | `POST /v1/auth/register` with valid payload | Creates user, no password hash in response | `apps/api/test/app.e2e-spec.ts` (`/v1/auth/register creates user`) |
+| Duplicate usernames | Register same username twice | Returns `409` | `apps/api/test/app.e2e-spec.ts` (`rejects duplicated username`) |
+| Login with persisted users | `POST /v1/auth/token` after register | Returns `200` with access token | `apps/api/test/app.e2e-spec.ts` (`authenticates persisted user`) |
+| Protected products route | `GET /v1/products` without token | Returns `401` | `apps/api/test/app.e2e-spec.ts` (`requires auth`) |
+| Authorized read access | `GET /v1/products` with user token | Returns paginated products | `apps/api/test/app.e2e-spec.ts` (`applies pagination for authenticated user`) |
+| Unauthorized write access | `POST /v1/products` with user token | Returns `403` | `apps/api/test/app.e2e-spec.ts` (`denies user role`) |
+| Frontend route protection | Access private route unauthenticated | Redirect to `/login` | `apps/web/src/app/core/guards/auth.guard.spec.ts` |
+| Frontend guest protection | Access login/register authenticated | Redirect to `/products` | `apps/web/src/app/core/guards/guest.guard.spec.ts` |
+| Frontend token propagation | API request with session token | Sends `Authorization` header | `apps/web/src/app/core/http/auth.interceptor.spec.ts` |
+| UI login happy path | Submit valid credentials | Calls auth API and navigates to `/products` | `apps/web/src/app/features/auth/pages/login.page.spec.ts` |
+| UI login rejection path | Login with invalid credentials | Shows actionable error | `apps/web/src/app/features/auth/pages/login.page.spec.ts` |
+| UI products integration | Products page init with valid session | Calls API and renders list state | `apps/web/src/app/features/products/pages/products.page.spec.ts` |
+| UI session expiry handling | Products API returns `401` | Clears session and redirects to `/login` | `apps/web/src/app/features/products/pages/products.page.spec.ts` |
+
+## Command Evidence
+Executed on `2026-02-12`:
+
+```bash
+pnpm --filter web lint
+pnpm --filter web test
+pnpm --filter web build
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Observed result:
+- `web lint`: pass
+- `web test`: pass (`9` files, `18` tests)
+- `web build`: pass
+- workspace `lint/test/build`: pass
+
+## Residual Risks
+1. Frontend flow is validated with unit/component tests, but not with full browser e2e (Playwright/Cypress) against a running API.
+2. JWT expiry is indirectly covered (401 handling), but no deterministic test for near-expiry refresh windows because refresh token flow is out of scope.
+3. Production Supabase networking and permission policies still depend on environment parity; local tests mainly validate app logic and contracts.


### PR DESCRIPTION
## Linked Issue
- [x] PR description includes Closes #<issue_number>
- [x] Linked issue has exactly one gent:* label

Closes #24

## Scope
- [x] This PR implements only the issue scope and acceptance criteria
- [x] Issue status moved to In Review in GitHub Project

## Changes
- Added frontend tests for login happy/rejection path in pps/web/src/app/features/auth/pages/login.page.spec.ts.
- Added frontend tests for protected products page load and 401 session-expiry handling in pps/web/src/app/features/products/pages/products.page.spec.ts.
- Added QA evidence artifact with risk matrix, acceptance mapping, command results, and residual risks in docs/qa/qa-01-auth-flow-quality-gate.md.

## Validation
- [x] pnpm lint
- [x] pnpm test
- [x] pnpm build

## Risks / Notes
- Full browser e2e is still pending (current coverage is unit/component + API e2e).
- Token refresh flow is out of current scope.