### PR TITLE
fix(release): restore Angular GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy-web-pages.yml
+++ b/.github/workflows/deploy-web-pages.yml
@@ -47,8 +47,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Write runtime config for Pages
+        env:
+          WEB_API_BASE_URL: ${{ vars.WEB_API_BASE_URL }}
+        run: |
+          API_BASE_URL="$WEB_API_BASE_URL"
+          if [ -z "$API_BASE_URL" ]; then
+            API_BASE_URL="https://ia-pm-development-api.vercel.app/v1"
+          fi
+          cat <<EOF > apps/web/public/env.js
+          window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};
+          window.__APP_CONFIG__.apiBaseUrl = '$API_BASE_URL';
+          EOF
+          echo "Using API base URL: $API_BASE_URL"
+
       - name: Build Angular app
-        run: pnpm --filter web build -- --configuration production --base-href "/${{ github.event.repository.name }}/"
+        run: pnpm --filter web exec ng build --configuration production --base-href "/${{ github.event.repository.name }}/"
 
       - name: Resolve artifact path
         id: artifact
@@ -58,6 +72,11 @@ jobs:
           else
             echo "path=apps/web/dist/web" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Prepare SPA fallback files
+        run: |
+          cp "${{ steps.artifact.outputs.path }}/index.html" "${{ steps.artifact.outputs.path }}/404.html"
+          touch "${{ steps.artifact.outputs.path }}/.nojekyll"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,3 +28,9 @@ Estructura base feature-first en `apps/web/src/app`:
 
 - Tailwind CSS habilitado con `@tailwindcss/postcss`.
 - Entrada global en `src/styles.scss` con variables y utilidades base (`bg-shell`).
+
+## Runtime API config
+
+- El frontend resuelve la base API desde `window.__APP_CONFIG__.apiBaseUrl` (archivo `public/env.js`).
+- Fallback local: `http://localhost:3000/v1`.
+- En GitHub Pages, el workflow escribe `env.js` usando la variable `WEB_API_BASE_URL`.

--- a/apps/web/public/env.js
+++ b/apps/web/public/env.js
@@ -1,0 +1,2 @@
+window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};
+window.__APP_CONFIG__.apiBaseUrl = 'http://localhost:3000/v1';

--- a/apps/web/src/app/core/config/api-base-url.token.spec.ts
+++ b/apps/web/src/app/core/config/api-base-url.token.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { API_BASE_URL } from './api-base-url.token';
+
+interface RuntimeConfigGlobal {
+  __APP_CONFIG__?: {
+    apiBaseUrl?: string;
+  };
+}
+
+describe('API_BASE_URL token', () => {
+  const runtimeConfigGlobal = globalThis as typeof globalThis & RuntimeConfigGlobal;
+
+  afterEach(() => {
+    delete runtimeConfigGlobal.__APP_CONFIG__;
+    TestBed.resetTestingModule();
+  });
+
+  it('uses localhost fallback when runtime config is missing', () => {
+    const baseUrl = TestBed.inject(API_BASE_URL);
+
+    expect(baseUrl).toBe('http://localhost:3000/v1');
+  });
+
+  it('uses runtime apiBaseUrl and normalizes trailing slash', () => {
+    runtimeConfigGlobal.__APP_CONFIG__ = {
+      apiBaseUrl: 'https://ia-pm-development-api.vercel.app/v1/',
+    };
+
+    const baseUrl = TestBed.inject(API_BASE_URL);
+
+    expect(baseUrl).toBe('https://ia-pm-development-api.vercel.app/v1');
+  });
+});

--- a/apps/web/src/app/core/config/api-base-url.token.ts
+++ b/apps/web/src/app/core/config/api-base-url.token.ts
@@ -1,6 +1,23 @@
 import { InjectionToken } from '@angular/core';
 
+const DEFAULT_API_BASE_URL = 'http://localhost:3000/v1';
+
+interface RuntimeConfig {
+  apiBaseUrl?: string;
+}
+
+const normalizeApiBaseUrl = (value: string): string => value.replace(/\/+$/, '');
+
+const resolveApiBaseUrl = (): string => {
+  const runtimeConfig = (
+    globalThis as typeof globalThis & { __APP_CONFIG__?: RuntimeConfig }
+  ).__APP_CONFIG__;
+  const apiBaseUrl = runtimeConfig?.apiBaseUrl ?? DEFAULT_API_BASE_URL;
+
+  return normalizeApiBaseUrl(apiBaseUrl);
+};
+
 export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL', {
   providedIn: 'root',
-  factory: () => 'http://localhost:3000/v1',
+  factory: () => resolveApiBaseUrl(),
 });

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <script src="env.js"></script>
 </head>
 <body>
   <app-root></app-root>

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -54,6 +54,11 @@ pnpm build
 2. Si falla por permisos, habilitar Pages en el repo (source: GitHub Actions).
 3. Push a `main` con cambios en `apps/web`.
 4. Workflow: `.github/workflows/deploy-web-pages.yml`.
+5. Configurar variable de repositorio `WEB_API_BASE_URL` con la URL del API publicada (ejemplo: `https://ia-pm-development-api.vercel.app/v1`).
+
+Notas operativas:
+- Si `WEB_API_BASE_URL` no existe, el workflow usa fallback `https://ia-pm-development-api.vercel.app/v1`.
+- El deploy genera `404.html` a partir de `index.html` para soportar refresh en rutas SPA (`/login`, `/products`).
 
 ## Deploy API (Render)
 1. Usar `Blueprint` de Render con `render.yaml` (recomendado).


### PR DESCRIPTION
## Linked Issue
- [x] PR description includes Closes #<issue_number>
- [x] Linked issue has exactly one gent:* label

Closes #31

## Scope
- [x] This PR implements only the issue scope and acceptance criteria
- [x] Issue status moved to In Review in GitHub Project

## Changes
- Fixed GitHub Pages build command in .github/workflows/deploy-web-pages.yml to avoid invalid 
g build -- --... invocation.
- Added runtime web config generation (nv.js) during Pages build using repository variable WEB_API_BASE_URL with safe fallback.
- Added SPA fallback generation (404.html) and .nojekyll in Pages artifact.
- Updated frontend runtime API URL resolution via window.__APP_CONFIG__.apiBaseUrl with localhost fallback.
- Added test coverage for runtime API base URL token behavior.
- Updated docs: docs/runbooks/local-dev.md and pps/web/README.md.

## Validation
- [x] pnpm lint
- [x] pnpm test
- [x] pnpm build

## Risks / Notes
- Required repository variable for production API target: WEB_API_BASE_URL.
- If not configured, workflow falls back to https://ia-pm-development-api.vercel.app/v1.