### PR TITLE
fix(api): correct wildcard CORS behavior for web clients

### DIFF
--- a/apps/api/src/config/app.config.spec.ts
+++ b/apps/api/src/config/app.config.spec.ts
@@ -1,0 +1,38 @@
+import appConfig from './app.config';
+
+describe('appConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.APP_CORS_ORIGINS;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses wildcard CORS origin when APP_CORS_ORIGINS is not set', () => {
+    const config = appConfig();
+
+    expect(config.cors.origins).toBe('*');
+  });
+
+  it('uses explicit CORS origins list when APP_CORS_ORIGINS has values', () => {
+    process.env.APP_CORS_ORIGINS =
+      'https://ridelhi.github.io, http://localhost:4200';
+    const config = appConfig();
+
+    expect(config.cors.origins).toEqual([
+      'https://ridelhi.github.io',
+      'http://localhost:4200',
+    ]);
+  });
+
+  it('treats wildcard marker as wildcard origin', () => {
+    process.env.APP_CORS_ORIGINS = '*';
+    const config = appConfig();
+
+    expect(config.cors.origins).toBe('*');
+  });
+});

--- a/apps/api/src/config/app.config.ts
+++ b/apps/api/src/config/app.config.ts
@@ -9,7 +9,7 @@ export interface AppConfig {
   environment: AppEnvironment;
   port: number;
   cors: {
-    origins: string[];
+    origins: string | string[];
     credentials: boolean;
   };
   docs: {
@@ -50,9 +50,9 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   return fallback;
 }
 
-function parseOrigins(value: string | undefined): string[] {
+function parseOrigins(value: string | undefined): string | string[] {
   if (!value || value.trim().length === 0) {
-    return ['*'];
+    return '*';
   }
 
   const origins = value
@@ -60,7 +60,15 @@ function parseOrigins(value: string | undefined): string[] {
     .map((origin) => origin.trim())
     .filter((origin) => origin.length > 0);
 
-  return origins.length > 0 ? origins : ['*'];
+  if (origins.length === 0) {
+    return '*';
+  }
+
+  if (origins.includes('*')) {
+    return '*';
+  }
+
+  return origins;
 }
 
 function parseDocsPath(value: string | undefined): string {

--- a/docs/runbooks/render-api-deploy.md
+++ b/docs/runbooks/render-api-deploy.md
@@ -57,6 +57,10 @@ curl https://<tu-servicio>.onrender.com/v1/health/live
 curl https://<tu-servicio>.onrender.com/v1
 ```
 
+Recomendacion CORS para GitHub Pages:
+- `APP_CORS_ORIGINS=https://ridelhi.github.io,http://localhost:4200`
+- Usa solo origins (sin path), por ejemplo `https://ridelhi.github.io` y no `https://ridelhi.github.io/ia-pm-development`.
+
 ## Nota operativa
 - El API usa `PORT` de entorno (inyectado por Render), no requiere adaptador serverless.
 - Si no puedes usar Blueprint, crear `Web Service` manual con los mismos comandos y health check.


### PR DESCRIPTION
## Linked Issue
- [x] PR description includes Closes #<issue_number>
- [x] Linked issue has exactly one gent:* label

Closes #33

## Scope
- [x] This PR implements only the issue scope and acceptance criteria
- [x] Issue status moved to In Review in GitHub Project

## Changes
- Fixed CORS origin parsing so APP_CORS_ORIGINS=* is treated as wildcard (*) instead of literal array entry (['*']).
- Preserved support for explicit CSV origin lists.
- Added unit tests for app config CORS parsing behavior in pps/api/src/config/app.config.spec.ts.
- Updated Render runbook with recommended CORS value for GitHub Pages origin.

## Validation
- [x] pnpm lint
- [x] pnpm test
- [x] pnpm build

## Risks / Notes
- Deploy target environments (Render/Vercel) must still have correct APP_CORS_ORIGINS value (https://ridelhi.github.io or *).