### PR TITLE
FE-06: Estandarizar stores frontend con @ngrx/signals

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,8 @@
     "@angular/forms": "^21.1.0",
     "@angular/platform-browser": "^21.1.0",
     "@angular/router": "^21.1.0",
+    "@ngrx/operators": "^21.0.1",
+    "@ngrx/signals": "^21.0.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/apps/web/src/app/features/auth/data-access/auth-api.service.spec.ts
+++ b/apps/web/src/app/features/auth/data-access/auth-api.service.spec.ts
@@ -9,10 +9,12 @@ import { API_BASE_URL } from '../../../core/config/api-base-url.token';
 import { AuthApiService } from './auth-api.service';
 import { AuthStore } from '../state/auth.store';
 
+type AuthStoreInstance = InstanceType<typeof AuthStore>;
+
 describe('AuthApiService', () => {
   let service: AuthApiService;
   let httpController: HttpTestingController;
-  let authStore: AuthStore;
+  let authStore: AuthStoreInstance;
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/apps/web/src/app/features/auth/state/auth.store.spec.ts
+++ b/apps/web/src/app/features/auth/state/auth.store.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { AuthStore } from './auth.store';
 
+type AuthStoreInstance = InstanceType<typeof AuthStore>;
+
 describe('AuthStore', () => {
-  let store: AuthStore;
+  let store: AuthStoreInstance;
 
   beforeEach(() => {
     localStorage.clear();

--- a/apps/web/src/app/features/products/state/products-page.state.ts
+++ b/apps/web/src/app/features/products/state/products-page.state.ts
@@ -1,15 +1,17 @@
 import type { Product } from '../domain/products.models';
 
-export interface ProductsPageState {
+export interface ProductsState {
   products: Product[];
   loading: boolean;
   error: string | null;
+  errorCode: number | null;
   query: string;
 }
 
-export const initialProductsPageState: ProductsPageState = {
+export const initialProductsState: ProductsState = {
   products: [],
   loading: false,
   error: null,
+  errorCode: null,
   query: '',
 };

--- a/apps/web/src/app/features/products/state/products.store.spec.ts
+++ b/apps/web/src/app/features/products/state/products.store.spec.ts
@@ -1,0 +1,93 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { Observable, of, throwError } from 'rxjs';
+import { ProductsApiService } from '../data-access/products-api.service';
+import type { PaginatedProductsResponse } from '../domain/products.models';
+import { ProductsStore } from './products.store';
+
+type ProductsStoreInstance = InstanceType<typeof ProductsStore>;
+
+describe('ProductsStore', () => {
+  let listProductsImplementation: (
+    query?: string,
+  ) => Observable<PaginatedProductsResponse>;
+  let listProductsQueries: string[];
+  let store: ProductsStoreInstance;
+
+  const productsApiServiceMock = {
+    listProducts(query = '') {
+      listProductsQueries.push(query);
+      return listProductsImplementation(query);
+    },
+  };
+
+  beforeEach(() => {
+    listProductsQueries = [];
+    listProductsImplementation = () =>
+      of({
+        data: [],
+        meta: {
+          page: 1,
+          limit: 20,
+          total: 0,
+          totalPages: 0,
+        },
+      });
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ProductsApiService,
+          useValue: productsApiServiceMock,
+        },
+      ],
+    });
+
+    store = TestBed.inject(ProductsStore);
+  });
+
+  it('loads products and updates state', async () => {
+    listProductsImplementation = () =>
+      of({
+        data: [
+          {
+            id: 'prod-01',
+            sku: 'SKU-01',
+            name: 'Product 01',
+            quantity: 2,
+            unitPriceCents: 1500,
+            status: 'active',
+            location: 'A-01',
+            createdAt: '2026-02-12T00:00:00.000Z',
+            updatedAt: '2026-02-12T00:00:00.000Z',
+          },
+        ],
+        meta: {
+          page: 1,
+          limit: 20,
+          total: 1,
+          totalPages: 1,
+        },
+      });
+
+    store.loadProducts('sku-01');
+    await Promise.resolve();
+
+    expect(listProductsQueries).toEqual(['sku-01']);
+    expect(store.products().length).toBe(1);
+    expect(store.loading()).toBe(false);
+    expect(store.error()).toBeNull();
+  });
+
+  it('stores error metadata on unauthorized response', async () => {
+    listProductsImplementation = () =>
+      throwError(() => new HttpErrorResponse({ status: 401 }));
+
+    store.loadProducts('');
+    await Promise.resolve();
+
+    expect(store.loading()).toBe(false);
+    expect(store.errorCode()).toBe(401);
+    expect(store.error()).toContain('sesión expiró');
+  });
+});

--- a/apps/web/src/app/features/products/state/products.store.ts
+++ b/apps/web/src/app/features/products/state/products.store.ts
@@ -1,0 +1,80 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { computed, inject } from '@angular/core';
+import { tapResponse } from '@ngrx/operators';
+import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { pipe, switchMap, tap } from 'rxjs';
+import { ProductsApiService } from '../data-access/products-api.service';
+import { initialProductsState, type ProductsState } from './products-page.state';
+
+function resolveProductsErrorMessage(error: unknown): string {
+  if (error instanceof HttpErrorResponse) {
+    if (error.status === 401) {
+      return 'Tu sesión expiró. Vuelve a iniciar sesión.';
+    }
+
+    if (error.status === 403) {
+      return 'No tienes permisos para consultar productos.';
+    }
+  }
+
+  return 'No se pudo cargar la lista de productos.';
+}
+
+function resolveProductsErrorCode(error: unknown): number | null {
+  if (error instanceof HttpErrorResponse) {
+    return error.status;
+  }
+
+  return null;
+}
+
+export const ProductsStore = signalStore(
+  { providedIn: 'root' },
+  withState<ProductsState>(initialProductsState),
+  withComputed(({ products, loading }) => ({
+    isEmpty: computed(() => !loading() && products().length === 0),
+  })),
+  withMethods((store, productsApiService = inject(ProductsApiService)) => ({
+    loadProducts: rxMethod<string>(
+      pipe(
+        tap((query) => {
+          patchState(store, {
+            query,
+            loading: true,
+            error: null,
+            errorCode: null,
+          });
+        }),
+        switchMap((query) =>
+          productsApiService.listProducts(query).pipe(
+            tapResponse({
+              next: (response) => {
+                patchState(store, {
+                  products: response.data,
+                });
+              },
+              error: (error) => {
+                patchState(store, {
+                  error: resolveProductsErrorMessage(error),
+                  errorCode: resolveProductsErrorCode(error),
+                });
+              },
+              finalize: () => {
+                patchState(store, {
+                  loading: false,
+                });
+              },
+            }),
+          ),
+        ),
+      ),
+    ),
+    clearError(): void {
+      patchState(store, {
+        error: null,
+        errorCode: null,
+      });
+    },
+  })),
+);

--- a/docs/runbooks/angular-frontend-architecture.md
+++ b/docs/runbooks/angular-frontend-architecture.md
@@ -51,3 +51,10 @@ apps/web/src/app
 
 - FE-05 focuses on structural refactor without behavior changes.
 - FE-06 standardizes stores with `@ngrx/signals` on top of this structure.
+
+## Store Standard
+
+- One store per feature in `features/<feature>/state`.
+- Use `signalStore` with `withState`, `withComputed`, `withMethods`.
+- Use `rxMethod` for side effects and API calls.
+- Keep error/loading/data state explicit inside store state.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,12 @@ importers:
       '@angular/router':
         specifier: ^21.1.0
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2))(@angular/platform-browser@21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)))(rxjs@7.8.2)
+      '@ngrx/operators':
+        specifier: ^21.0.1
+        version: 21.0.1(rxjs@7.8.2)
+      '@ngrx/signals':
+        specifier: ^21.0.1
+        version: 21.0.1(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2))(rxjs@7.8.2)
       rxjs:
         specifier: ~7.8.0
         version: 7.8.2
@@ -1756,6 +1762,20 @@ packages:
       '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
       '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
       reflect-metadata: ^0.1.13 || ^0.2.0
+
+  '@ngrx/operators@21.0.1':
+    resolution: {integrity: sha512-CfSh9MzQoIjbipSJ4q1+ZhcY537I5th4hNdNiWHu/egx2+SgFUZlOcQ6E9c+DJMsVkYOoIYhKX1E/bYlFBqXJw==}
+    peerDependencies:
+      rxjs: ^6.5.3 || ^7.4.0
+
+  '@ngrx/signals@21.0.1':
+    resolution: {integrity: sha512-krmZDhgHrnmZrxfEJ41bp/aM8Mc55k5B2N7oCLT5w4M3YbOkbnWPkP6bBWMv4XPI+2rqVgkLRW6DaWLwoESaBw==}
+    peerDependencies:
+      '@angular/core': ^21.0.0
+      rxjs: ^6.5.3 || ^7.4.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -7247,6 +7267,18 @@ snapshots:
       '@nestjs/common': 11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.13(@nestjs/common@11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
+
+  '@ngrx/operators@21.0.1(rxjs@7.8.2)':
+    dependencies:
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@ngrx/signals@21.0.1(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2))(rxjs@7.8.2)':
+    dependencies:
+      '@angular/core': 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)
+      tslib: 2.8.1
+    optionalDependencies:
+      rxjs: 7.8.2
 
   '@noble/hashes@1.8.0': {}
 


### PR DESCRIPTION
## Linked Issue
- Closes #37

## Scope
- Estandarización de stores con `@ngrx/signals` para auth y products.

## Changes
- Instalación de `@ngrx/signals` y `@ngrx/operators` en `apps/web`.
- Migración de `AuthStore` a `signalStore` con:
  - `withState`
  - `withComputed`
  - `withMethods`
  - `withHooks` (persistencia en localStorage)
- Creación de `ProductsStore` con `signalStore` + `rxMethod` para side effects HTTP.
- `ProductsPageComponent` ahora consume `ProductsStore` (sin llamadas API directas).
- Nuevos tests de store para products y ajuste de specs existentes.
- Documentación de estándar de stores en runbook de arquitectura.

## Validation
- pnpm lint
- pnpm test
- pnpm build

## Risks / Notes
- Se mantiene el flujo de logout por 401 desde la página contenedora usando señales de error del store.