### PR TITLE
refactor(web): desacoplar UI de estado y fortalecer accesibilidad

### DIFF
--- a/apps/web/src/app/features/auth/ui/pages/login.page.ts
+++ b/apps/web/src/app/features/auth/ui/pages/login.page.ts
@@ -24,11 +24,12 @@ import { AuthApiService } from '../../data-access/auth-api.service';
         </article>
 
         <article class="p-8 md:p-10">
-          <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4">
+          <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4" novalidate>
             <label class="block space-y-1">
               <span class="text-sm font-semibold text-slate-700">Usuario</span>
               <input
                 formControlName="username"
+                [attr.aria-invalid]="form.controls.username.invalid && form.controls.username.touched"
                 autocomplete="username"
                 class="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm outline-none ring-cyan-400 transition focus:ring-2"
                 placeholder="warehouse.user"
@@ -40,6 +41,7 @@ import { AuthApiService } from '../../data-access/auth-api.service';
               <span class="text-sm font-semibold text-slate-700">Password</span>
               <input
                 formControlName="password"
+                [attr.aria-invalid]="form.controls.password.invalid && form.controls.password.touched"
                 autocomplete="current-password"
                 class="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm outline-none ring-cyan-400 transition focus:ring-2"
                 placeholder="StrongPassword123!"
@@ -48,18 +50,27 @@ import { AuthApiService } from '../../data-access/auth-api.service';
             </label>
 
             @if (errorMessage()) {
-              <p class="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+              <p
+                aria-live="assertive"
+                class="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700"
+                role="alert"
+              >
                 {{ errorMessage() }}
               </p>
             }
 
             @if (infoMessage()) {
-              <p class="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+              <p
+                aria-live="polite"
+                class="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+                role="status"
+              >
                 {{ infoMessage() }}
               </p>
             }
 
             <button
+              [attr.aria-busy]="isSubmitting()"
               [disabled]="isSubmitting()"
               class="w-full rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
               type="submit"

--- a/apps/web/src/app/features/auth/ui/pages/register.page.spec.ts
+++ b/apps/web/src/app/features/auth/ui/pages/register.page.spec.ts
@@ -1,0 +1,79 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+import { AuthApiService } from '../../data-access/auth-api.service';
+import { RegisterPageComponent } from './register.page';
+
+describe('RegisterPageComponent', () => {
+  let registerImplementation: (
+    payload: Readonly<{ username: string; password: string }>,
+  ) => Observable<unknown>;
+  let registerCalls: { username: string; password: string }[];
+
+  const authApiServiceMock = {
+    register(payload: Readonly<{ username: string; password: string }>) {
+      registerCalls.push({ ...payload });
+      return registerImplementation(payload);
+    },
+  };
+
+  beforeEach(async () => {
+    registerCalls = [];
+    registerImplementation = () =>
+      of({
+        id: 'usr_01',
+        username: 'warehouse.user',
+        role: 'user',
+        createdAt: '2026-02-13T00:00:00.000Z',
+        updatedAt: '2026-02-13T00:00:00.000Z',
+      });
+
+    await TestBed.configureTestingModule({
+      imports: [RegisterPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthApiService,
+          useValue: authApiServiceMock,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('does not call API when form is invalid', async () => {
+    const fixture = TestBed.createComponent(RegisterPageComponent);
+    const component = fixture.componentInstance;
+
+    component.form.setValue({
+      username: '',
+      password: '',
+    });
+    await component.submit();
+
+    expect(registerCalls).toEqual([]);
+    expect(component.errorMessage()).toContain('Completa usuario');
+  });
+
+  it('shows conflict message on 409 response', async () => {
+    registerImplementation = () =>
+      throwError(() => new HttpErrorResponse({ status: 409 }));
+    const fixture = TestBed.createComponent(RegisterPageComponent);
+    const component = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    const navigateCalls: unknown[] = [];
+    router.navigate = ((...args: unknown[]) => {
+      navigateCalls.push(args);
+      return Promise.resolve(true);
+    }) as Router['navigate'];
+
+    component.form.setValue({
+      username: 'warehouse.user',
+      password: 'StrongPassword123!',
+    });
+    await component.submit();
+
+    expect(component.errorMessage()).toContain('ya existe');
+    expect(navigateCalls).toEqual([]);
+  });
+});

--- a/apps/web/src/app/features/auth/ui/pages/register.page.ts
+++ b/apps/web/src/app/features/auth/ui/pages/register.page.ts
@@ -19,11 +19,12 @@ import { AuthApiService } from '../../data-access/auth-api.service';
           Endpoint backend: <code>/v1/auth/register</code>
         </p>
 
-        <form [formGroup]="form" (ngSubmit)="submit()" class="mt-6 space-y-4">
+        <form [formGroup]="form" (ngSubmit)="submit()" class="mt-6 space-y-4" novalidate>
           <label class="block space-y-1">
             <span class="text-sm font-semibold text-slate-700">Usuario</span>
             <input
               formControlName="username"
+              [attr.aria-invalid]="form.controls.username.invalid && form.controls.username.touched"
               autocomplete="username"
               class="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm outline-none ring-cyan-400 transition focus:ring-2"
               placeholder="warehouse.user"
@@ -35,6 +36,7 @@ import { AuthApiService } from '../../data-access/auth-api.service';
             <span class="text-sm font-semibold text-slate-700">Password</span>
             <input
               formControlName="password"
+              [attr.aria-invalid]="form.controls.password.invalid && form.controls.password.touched"
               autocomplete="new-password"
               class="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm outline-none ring-cyan-400 transition focus:ring-2"
               placeholder="StrongPassword123!"
@@ -43,18 +45,27 @@ import { AuthApiService } from '../../data-access/auth-api.service';
           </label>
 
           @if (errorMessage()) {
-            <p class="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            <p
+              aria-live="assertive"
+              class="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700"
+              role="alert"
+            >
               {{ errorMessage() }}
             </p>
           }
 
           @if (successMessage()) {
-            <p class="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+            <p
+              aria-live="polite"
+              class="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+              role="status"
+            >
               {{ successMessage() }}
             </p>
           }
 
           <button
+            [attr.aria-busy]="isSubmitting()"
             [disabled]="isSubmitting()"
             class="w-full rounded-xl bg-cyan-700 px-4 py-2 text-sm font-semibold text-white transition hover:bg-cyan-600 disabled:cursor-not-allowed disabled:opacity-60"
             type="submit"

--- a/apps/web/src/app/features/products/ui/components/products-feedback.component.spec.ts
+++ b/apps/web/src/app/features/products/ui/components/products-feedback.component.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+import { ProductsFeedbackComponent } from './products-feedback.component';
+
+describe('ProductsFeedbackComponent', () => {
+  it('renders error feedback when error is present', () => {
+    const fixture = TestBed.createComponent(ProductsFeedbackComponent);
+
+    fixture.componentRef.setInput('errorMessage', 'Error de carga');
+    fixture.componentRef.setInput('isEmpty', false);
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement as HTMLElement;
+    expect(html.textContent).toContain('Error de carga');
+  });
+
+  it('renders empty feedback when list is empty and no error exists', () => {
+    const fixture = TestBed.createComponent(ProductsFeedbackComponent);
+
+    fixture.componentRef.setInput('errorMessage', null);
+    fixture.componentRef.setInput('isEmpty', true);
+    fixture.detectChanges();
+
+    const html = fixture.nativeElement as HTMLElement;
+    expect(html.textContent).toContain('No hay productos');
+  });
+});

--- a/apps/web/src/app/features/products/ui/components/products-feedback.component.ts
+++ b/apps/web/src/app/features/products/ui/components/products-feedback.component.ts
@@ -1,0 +1,28 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-products-feedback',
+  template: `
+    @if (errorMessage()) {
+      <section
+        aria-live="assertive"
+        class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
+        role="alert"
+      >
+        {{ errorMessage() }}
+      </section>
+    } @else if (isEmpty()) {
+      <section
+        aria-live="polite"
+        class="rounded-2xl border border-stone-200 bg-white px-4 py-8 text-center text-sm text-slate-600 shadow-sm"
+      >
+        No hay productos para mostrar con los filtros actuales.
+      </section>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductsFeedbackComponent {
+  readonly errorMessage = input<string | null>(null);
+  readonly isEmpty = input(false);
+}

--- a/apps/web/src/app/features/products/ui/components/products-grid.component.ts
+++ b/apps/web/src/app/features/products/ui/components/products-grid.component.ts
@@ -1,0 +1,38 @@
+import { CurrencyPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import type { Product } from '../../domain/products.models';
+
+@Component({
+  selector: 'app-products-grid',
+  imports: [CurrencyPipe],
+  template: `
+    <section class="grid gap-3 md:grid-cols-2">
+      @for (product of products(); track product.id) {
+        <article class="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm">
+          <p class="text-xs font-semibold uppercase tracking-[0.15em] text-cyan-700">
+            {{ product.sku }}
+          </p>
+          <h2 class="mt-1 text-lg font-semibold text-slate-900">{{ product.name }}</h2>
+          <p class="mt-2 text-sm text-slate-600">
+            Cantidad:
+            <span class="font-semibold text-slate-800">{{ product.quantity }}</span>
+          </p>
+          <p class="text-sm text-slate-600">
+            Precio:
+            <span class="font-semibold text-slate-800">{{
+              product.unitPriceCents / 100 | currency: 'USD'
+            }}</span>
+          </p>
+          <p class="text-sm text-slate-600">
+            Estado:
+            <span class="font-semibold text-slate-800">{{ product.status }}</span>
+          </p>
+        </article>
+      }
+    </section>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductsGridComponent {
+  readonly products = input.required<Product[]>();
+}

--- a/apps/web/src/app/features/products/ui/components/products-search-form.component.spec.ts
+++ b/apps/web/src/app/features/products/ui/components/products-search-form.component.spec.ts
@@ -1,0 +1,32 @@
+import { TestBed } from '@angular/core/testing';
+import { ProductsSearchFormComponent } from './products-search-form.component';
+
+describe('ProductsSearchFormComponent', () => {
+  it('emits query change on input event', () => {
+    const fixture = TestBed.createComponent(ProductsSearchFormComponent);
+    const component = fixture.componentInstance;
+    const emittedValues: string[] = [];
+    const inputElement = document.createElement('input');
+    inputElement.value = 'SKU-01';
+
+    component.queryChange.subscribe((value) => emittedValues.push(value));
+    component.onQueryInput({
+      target: inputElement,
+    } as unknown as Event);
+
+    expect(emittedValues).toEqual(['SKU-01']);
+  });
+
+  it('emits search event on submit', () => {
+    const fixture = TestBed.createComponent(ProductsSearchFormComponent);
+    const component = fixture.componentInstance;
+    let emitted = false;
+
+    component.searchRequested.subscribe(() => {
+      emitted = true;
+    });
+    component.submitSearch();
+
+    expect(emitted).toBe(true);
+  });
+});

--- a/apps/web/src/app/features/products/ui/components/products-search-form.component.ts
+++ b/apps/web/src/app/features/products/ui/components/products-search-form.component.ts
@@ -1,0 +1,48 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-products-search-form',
+  template: `
+    <form class="flex flex-wrap gap-3" (ngSubmit)="submitSearch()" novalidate>
+      <label class="sr-only" for="products-query">Buscar productos</label>
+      <input
+        id="products-query"
+        [value]="query()"
+        (input)="onQueryInput($event)"
+        aria-label="Buscar productos por nombre o SKU"
+        class="min-w-64 flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none ring-cyan-400 focus:ring-2"
+        placeholder="Buscar por nombre o SKU"
+        type="search"
+      />
+      <button
+        [attr.aria-busy]="loading()"
+        [disabled]="loading()"
+        class="rounded-lg bg-cyan-700 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-600 disabled:cursor-not-allowed disabled:opacity-60"
+        type="submit"
+      >
+        @if (loading()) { Cargando... } @else { Buscar }
+      </button>
+    </form>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductsSearchFormComponent {
+  readonly query = input('');
+  readonly loading = input(false);
+  readonly queryChange = output<string>();
+  readonly searchRequested = output<void>();
+
+  onQueryInput(event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    this.queryChange.emit(target.value);
+  }
+
+  submitSearch(): void {
+    this.searchRequested.emit();
+  }
+}

--- a/apps/web/src/app/features/products/ui/pages/products.page.spec.ts
+++ b/apps/web/src/app/features/products/ui/pages/products.page.spec.ts
@@ -22,6 +22,7 @@ describe('ProductsPageComponent', () => {
   const loadingSignal = signal(false);
   const errorSignal = signal<string | null>(null);
   const errorCodeSignal = signal<number | null>(null);
+  const isEmptySignal = signal(false);
   let loadProductsCalls: string[];
   let clearErrorCalls: number;
   let clearSessionCalls: number;
@@ -31,6 +32,7 @@ describe('ProductsPageComponent', () => {
     loading: loadingSignal,
     error: errorSignal,
     errorCode: errorCodeSignal,
+    isEmpty: isEmptySignal,
     loadProducts(query: string) {
       loadProductsCalls.push(query);
     },
@@ -54,6 +56,7 @@ describe('ProductsPageComponent', () => {
     loadingSignal.set(false);
     errorSignal.set(null);
     errorCodeSignal.set(null);
+    isEmptySignal.set(false);
     await TestBed.configureTestingModule({
       imports: [ProductsPageComponent],
       providers: [
@@ -84,6 +87,7 @@ describe('ProductsPageComponent', () => {
         updatedAt: '2026-02-12T00:00:00.000Z',
       },
     ]);
+    isEmptySignal.set(false);
     const fixture = TestBed.createComponent(ProductsPageComponent);
 
     fixture.detectChanges();
@@ -105,6 +109,7 @@ describe('ProductsPageComponent', () => {
     }) as Router['navigate'];
 
     errorCodeSignal.set(401);
+    isEmptySignal.set(false);
     fixture.detectChanges();
     await fixture.whenStable();
 

--- a/docs/runbooks/angular-frontend-architecture.md
+++ b/docs/runbooks/angular-frontend-architecture.md
@@ -58,3 +58,14 @@ apps/web/src/app
 - Use `signalStore` with `withState`, `withComputed`, `withMethods`.
 - Use `rxMethod` for side effects and API calls.
 - Keep error/loading/data state explicit inside store state.
+
+## UI Composition Standard
+
+- Pages act as containers and orchestrate navigation + store interactions.
+- Presentational components receive data via inputs and communicate via outputs.
+- Presentational components do not inject API services or feature stores.
+- Critical feedback states must be explicit and accessible:
+  - loading
+  - error (`role="alert"` for blocking errors)
+  - empty
+  - success/status (`aria-live="polite"` where appropriate)


### PR DESCRIPTION
## Summary\n- desacopla la pagina de productos en componentes presentacionales (search-form, eedback, grid) y deja products.page como contenedor\n- normaliza estados UX (loading/empty/error) con renderizado consistente\n- mejora accesibilidad en login/registro con atributos ARIA y feedback de estado\n- actualiza pruebas unitarias de componentes y paginas afectadas\n- documenta el estandar de composicion UI en docs/runbooks/angular-frontend-architecture.md\n\n## Validation\n- pnpm lint\n- pnpm test\n- pnpm build\n\nCloses #38