### PR TITLE
docs(web): integrar contexto IA y runbook MCP para Angular

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "pnpm",
+      "args": ["exec", "ng", "mcp", "--read-only"]
+    }
+  }
+}

--- a/.cursor/rules/angular-web.mdc
+++ b/.cursor/rules/angular-web.mdc
@@ -1,0 +1,40 @@
+---
+description: Angular 21 delivery rules for ia-pm-development
+globs:
+  - "apps/web/src/app/**/*.ts"
+  - "apps/web/src/app/**/*.html"
+alwaysApply: false
+---
+
+# Angular web rule
+
+## Architecture
+- Use feature-first folders and layer boundaries:
+  - `domain`, `data-access`, `state`, `ui`
+- No API calls in UI components.
+- Keep presentational components store-agnostic.
+
+## State
+- Standardize stores with `@ngrx/signals`.
+- Use `signalStore`, `withState`, `withComputed`, `withMethods`.
+- Use `rxMethod` for side effects.
+- Keep state transitions explicit for loading/error/data.
+
+## Angular conventions
+- Standalone components and `ChangeDetectionStrategy.OnPush`.
+- `input()` and `output()` APIs for component contracts.
+- Native control flow (`@if`, `@for`, `@switch`).
+- Avoid `any`; prefer strict, explicit typing.
+
+## UX and accessibility
+- Handle loading/empty/error/success states in feature pages.
+- Keep form feedback and focus behavior accessible.
+- Use semantic markup and ARIA attributes only where needed.
+
+## Delivery
+- Stay within issue scope.
+- Preserve `1 issue = 1 branch = 1 PR`.
+- Final validation must include:
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm build`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Copilot Instructions - ia-pm-development
+
+## Stack and architecture
+- Frontend: Angular 21 (`apps/web`), standalone components, signals-first.
+- Backend: NestJS 11 (`apps/api`).
+- Package manager: `pnpm` only.
+- Frontend architecture: feature-first, layered by `domain`, `data-access`, `state`, `ui`.
+
+## Frontend coding rules
+- Use strict TypeScript and avoid `any`.
+- Keep DTOs separate from domain models.
+- Keep API calls in `data-access` only.
+- Use `@ngrx/signals` stores in `features/*/state`.
+- Keep pages as containers; components as presentational units.
+- Cover loading, empty, error, and success states.
+- Prefer native control flow (`@if`, `@for`, `@switch`).
+
+## Agent-first delivery rules
+- Require linked issue with exactly one `agent:*` label.
+- Keep `1 issue = 1 branch = 1 PR`.
+- Include `Closes #<issue_number>` in PR body.
+- Validate and report:
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm build`
+
+## Source of truth
+- `AGENTS.md`
+- `docs/ai/angular-ai-professional-playbook.md`
+- `docs/runbooks/angular-frontend-architecture.md`
+- `docs/runbooks/angular-mcp-setup.md`

--- a/.instructions.md
+++ b/.instructions.md
@@ -1,0 +1,26 @@
+# Project Instructions for AI Assistants
+
+## Repository profile
+- Monorepo with Angular 21 + NestJS 11.
+- Use `pnpm` commands only.
+- Follow issue-driven delivery with one active owner role (`agent:*`).
+
+## Angular development contract
+- Use feature-first structure in `apps/web/src/app/features`.
+- Respect layer boundaries: `ui -> state -> data-access`.
+- Keep domain models and transport DTOs separated.
+- Standardize state with `@ngrx/signals`.
+- Keep UI components decoupled from stores and API services.
+- Enforce accessible loading/error/empty/success states.
+
+## Required validation
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+## Reference docs
+- `AGENTS.md`
+- `docs/ai/angular-ai-professional-playbook.md`
+- `docs/runbooks/angular-frontend-architecture.md`
+- `docs/runbooks/angular-mcp-setup.md`
+- `docs/ai/prompts/frontend-feature-signals-prompt.md`

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "angular-cli": {
+      "type": "stdio",
+      "command": "pnpm",
+      "args": ["exec", "ng", "mcp", "--read-only"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,10 @@ Operate as a professional software delivery agent for a monorepo with:
 - Workflow rules: `docs/runbooks/github-project-workflow.md`
 - Git strategy: `docs/runbooks/git-branching-model.md`
 - Operating model: `docs/ai/agent-operating-model.md`
+- Angular + AI playbook: `docs/ai/angular-ai-professional-playbook.md`
 - Backlog conventions: `docs/planning/github-project-backlog.md`
 - Local operation: `docs/runbooks/local-dev.md`
+- MCP setup: `docs/runbooks/angular-mcp-setup.md`
 
 ## Workflow Playbooks
 - New feature: `docs/ai/workflows/new-feature.md`
@@ -36,6 +38,9 @@ Operate as a professional software delivery agent for a monorepo with:
 - Feature specification: `docs/ai/prompts/feature-spec-prompt.md`
 - Code audit: `docs/ai/prompts/audit-prompt.md`
 - Refactor: `docs/ai/prompts/refactor-prompt.md`
+- Frontend feature (signals): `docs/ai/prompts/frontend-feature-signals-prompt.md`
+- Frontend refactor (signals): `docs/ai/prompts/frontend-refactor-signals-prompt.md`
+- Frontend audit (signals): `docs/ai/prompts/frontend-audit-signals-prompt.md`
 
 ## Role Activation
 Activate one primary role per task and keep it explicit:

--- a/docs/ai/agent-operating-model.md
+++ b/docs/ai/agent-operating-model.md
@@ -85,10 +85,25 @@ Usar estos artefactos para repetir procesos con consistencia:
   - `docs/ai/workflows/deploy.md`
 - Git strategy:
   - `docs/runbooks/git-branching-model.md`
+- Angular + AI:
+  - `docs/ai/angular-ai-professional-playbook.md`
+  - `docs/runbooks/angular-frontend-architecture.md`
+  - `docs/runbooks/angular-mcp-setup.md`
 - Prompt templates:
   - `docs/ai/prompts/feature-spec-prompt.md`
   - `docs/ai/prompts/audit-prompt.md`
   - `docs/ai/prompts/refactor-prompt.md`
+  - `docs/ai/prompts/frontend-feature-signals-prompt.md`
+  - `docs/ai/prompts/frontend-refactor-signals-prompt.md`
+  - `docs/ai/prompts/frontend-audit-signals-prompt.md`
+
+## Context files para asistentes IA
+Archivos versionados para mantener consistencia entre herramientas:
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `.instructions.md`
+- `.cursor/rules/angular-web.mdc`
+- `llms.txt`
 
 ## Operacion con GitHub CLI
 ```bash

--- a/docs/ai/angular-ai-professional-playbook.md
+++ b/docs/ai/angular-ai-professional-playbook.md
@@ -1,0 +1,129 @@
+# Angular 21 + AI Professional Playbook
+
+## Objective
+Define a single source of truth for Angular architecture, AI-assisted development, and `@ngrx/signals` conventions in this repository.
+
+## Scope
+- Applies to `apps/web` and all future frontend features.
+- Covers feature-first structure, state standards, AI context files, and delivery quality gates.
+
+## Architectural baseline
+
+### App layout
+```text
+apps/web/src/app
+  app.config.ts
+  app.routes.ts
+  core/
+  shared/
+  features/
+    <feature>/
+      domain/
+      data-access/
+      state/
+      ui/
+```
+
+### Layer responsibilities
+- `domain/`: DTOs, domain models, mappers, and pure business types.
+- `data-access/`: API clients and adapters only.
+- `state/`: signal stores and state transition logic.
+- `ui/`: containers, pages, and presentational components.
+
+### Dependency direction
+- `ui -> state -> data-access -> core`
+- `domain` is side-effect free and can be used by all feature layers.
+- Presentational components must not inject stores or API services.
+
+## `@ngrx/signals` standard
+
+### Store shape
+- One store per feature.
+- Explicit state fields: `data`, `loading`, `error`, plus feature fields (filters, pagination, ids).
+- Derived state with `withComputed`.
+- Side effects with `rxMethod` and explicit error mapping.
+
+### Store composition
+- Use `signalStore` with:
+  - `withState`
+  - `withComputed`
+  - `withMethods`
+  - `withHooks` when lifecycle wiring is required
+- Use pure updates through `patchState` and immutable payloads.
+- Do not use global mutable singleton state outside stores.
+
+### API boundary rule
+- API DTOs stay in `domain/dto` (or equivalent domain files).
+- Map DTOs to internal models before state update.
+- UI must consume internal models, not transport DTOs.
+
+## Angular implementation rules
+
+### Components
+- Keep components small and single-purpose.
+- Default to `ChangeDetectionStrategy.OnPush`.
+- Use `input()` / `output()` and signals for local state.
+- Prefer inline templates only for very small components.
+
+### Templates
+- Use native control flow (`@if`, `@for`, `@switch`).
+- Keep template logic simple; move branching to computed state when needed.
+- Do not add arrow functions or ad-hoc transformations in templates.
+
+### Services
+- Single responsibility per service.
+- `providedIn: 'root'` for singleton cross-feature services.
+- Use `inject()` over constructor injection where practical.
+
+### Accessibility baseline
+- Support clear focus order and visible focus state.
+- Use semantic roles and ARIA only when needed.
+- Expose loading/status updates with `aria-live` in critical flows.
+- Keep color contrast and form error feedback at WCAG AA level.
+
+## AI context stack (repo-level)
+
+### Instruction files
+- `AGENTS.md`: global non-negotiable workflow and role rules.
+- `.github/copilot-instructions.md`: GitHub Copilot repository behavior.
+- `.instructions.md`: VS Code Chat/Copilot project instructions.
+- `.cursor/rules/angular-web.mdc`: Cursor rule for Angular delivery.
+- `llms.txt`: compact index of architecture and workflow context.
+
+### Prompt templates
+- `docs/ai/prompts/frontend-feature-signals-prompt.md`
+- `docs/ai/prompts/frontend-refactor-signals-prompt.md`
+- `docs/ai/prompts/frontend-audit-signals-prompt.md`
+
+### Workflow references
+- `docs/ai/workflows/new-feature.md`
+- `docs/ai/workflows/review-pr.md`
+- `docs/ai/workflows/deploy.md`
+
+## Skills and role mapping
+- `agent:frontend`: `frontend-angular-delivery`
+- `agent:qa`: `qa-quality-gate`
+- `agent:release`: `release-cicd-operator`
+- `agent:pm`: `pm-github-orchestrator`
+- Backend support and patterns: `backend-nestjs-delivery`, `nestjs-best-practices`
+
+## Delivery contract per issue
+1. Issue has exactly one `agent:*` label.
+2. Branch is scoped to one issue.
+3. PR includes `Closes #<issue_number>`.
+4. Evidence includes:
+   - `pnpm lint`
+   - `pnpm test`
+   - `pnpm build`
+
+## References
+- Angular AI docs: https://angular.dev/ai
+- Develop with AI: https://angular.dev/ai/develop-with-ai
+- Angular AI design patterns: https://angular.dev/ai/design-patterns
+- Angular CLI MCP server: https://angular.dev/ai/mcp
+- Angular style guide: https://angular.dev/style-guide
+- Angular signals guide: https://angular.dev/guide/signals
+- Angular control flow guide: https://angular.dev/guide/templates/control-flow
+- Angular llms context: https://angular.dev/llms.txt
+- MCP security best practices: https://modelcontextprotocol.io/specification/2025-06-18/basic/security_best_practices
+- Web codegen scorer (Angular): https://github.com/angular/web-codegen-scorer

--- a/docs/ai/prompts/frontend-audit-signals-prompt.md
+++ b/docs/ai/prompts/frontend-audit-signals-prompt.md
@@ -1,0 +1,42 @@
+# Prompt Template: Frontend Audit (Angular + Signals)
+
+Use this template for risk-focused audits of Angular frontend PRs.
+
+```text
+Quiero una auditoria tecnica de esta PR frontend Angular.
+
+Contexto:
+- PR: <id>
+- Issue: <id>
+- Feature: <name>
+- Stack: Angular 21 + @ngrx/signals
+
+Instrucciones:
+1) Prioriza hallazgos reales por severidad:
+   - Alta: bugs, regresiones funcionales, riesgo de seguridad, accesibilidad critica
+   - Media: deuda que impacta mantenibilidad o testabilidad
+   - Baja: mejoras de claridad y consistencia
+2) Verifica arquitectura por capas:
+   - ui no consume API directo
+   - estado centralizado en signal store
+   - DTO/modelo separados
+3) Verifica UX states:
+   - loading, empty, error, success
+4) Verifica calidad Angular:
+   - control flow nativo
+   - signals/computed
+   - OnPush en componentes
+   - tipado estricto y sin any
+5) Verifica cobertura de pruebas y evidencia de:
+   - pnpm lint
+   - pnpm test
+   - pnpm build
+6) Cierra con veredicto:
+   - approved
+   - changes requested
+
+Salida:
+- Lista de findings con archivo y linea.
+- Riesgos residuales.
+- Gap entre acceptance criteria e implementacion.
+```

--- a/docs/ai/prompts/frontend-feature-signals-prompt.md
+++ b/docs/ai/prompts/frontend-feature-signals-prompt.md
@@ -1,0 +1,36 @@
+# Prompt Template: Frontend Feature (Angular + Signals)
+
+Use this template to define and implement a new Angular frontend feature with feature-first architecture and `@ngrx/signals`.
+
+```text
+Context:
+- Repo: ia-pm-development
+- Stack: Angular 21, TypeScript strict, @ngrx/signals
+- Issue: <issue_number and title>
+- Feature scope: <short description>
+
+Requirements:
+1) Propose a file-level plan under:
+   - features/<feature>/domain
+   - features/<feature>/data-access
+   - features/<feature>/state
+   - features/<feature>/ui
+2) Define domain model vs API DTO separation.
+3) Implement/adjust signal store using:
+   - signalStore
+   - withState / withComputed / withMethods
+   - rxMethod for side effects
+4) Keep container/page orchestration in ui/pages and presentational logic in ui/components.
+5) Cover loading/empty/error/success states.
+6) Include accessibility checks (labels, focus flow, aria-live where relevant).
+7) Add or update tests for changed behavior.
+8) Finish with validation evidence:
+   - pnpm lint
+   - pnpm test
+   - pnpm build
+
+Constraints:
+- Keep PR scoped to issue acceptance criteria.
+- Do not mix unrelated refactors.
+- Respond in Spanish and include file references.
+```

--- a/docs/ai/prompts/frontend-refactor-signals-prompt.md
+++ b/docs/ai/prompts/frontend-refactor-signals-prompt.md
@@ -1,0 +1,32 @@
+# Prompt Template: Frontend Refactor (Angular + Signals)
+
+Use this template for safe Angular refactors without functional regression.
+
+```text
+Necesito un refactor incremental en frontend Angular sin cambiar el comportamiento observable.
+
+Contexto:
+- Issue: <issue_number>
+- Area: <feature/path>
+- Restriccion principal: no romper flujo auth/products actual
+- Arquitectura objetivo: feature-first + @ngrx/signals
+
+Entrega requerida:
+1) Diagnostico actual:
+   - acoplamientos entre ui/state/data-access
+   - deuda de tipado, estado y testing
+2) Objetivo de refactor y criterios de salida.
+3) Plan por pasos pequenos con rollback facil.
+4) Cambios por capa (domain, data-access, state, ui).
+5) Riesgos y mitigaciones por paso.
+6) Pruebas de no-regresion necesarias.
+7) Evidencia final:
+   - pnpm lint
+   - pnpm test
+   - pnpm build
+
+Reglas:
+- Mantener 1 issue = 1 branch = 1 PR.
+- No introducir nuevas features fuera del scope.
+- Incluir referencias de archivos y lineas clave.
+```

--- a/docs/runbooks/angular-frontend-architecture.md
+++ b/docs/runbooks/angular-frontend-architecture.md
@@ -69,3 +69,12 @@ apps/web/src/app
   - error (`role="alert"` for blocking errors)
   - empty
   - success/status (`aria-live="polite"` where appropriate)
+
+## AI Alignment
+
+- Primary AI architecture guide: `docs/ai/angular-ai-professional-playbook.md`.
+- MCP setup and safety defaults: `docs/runbooks/angular-mcp-setup.md`.
+- Prompt templates for frontend work:
+  - `docs/ai/prompts/frontend-feature-signals-prompt.md`
+  - `docs/ai/prompts/frontend-refactor-signals-prompt.md`
+  - `docs/ai/prompts/frontend-audit-signals-prompt.md`

--- a/docs/runbooks/angular-mcp-setup.md
+++ b/docs/runbooks/angular-mcp-setup.md
@@ -1,0 +1,77 @@
+# Runbook: Angular MCP Setup
+
+## Objective
+Standardize safe MCP setup for Angular AI workflows in this repository.
+
+## Prerequisites
+- Node.js 22+
+- `pnpm` enabled in the environment
+- Workspace opened at repo root
+
+## Default policy
+- Use `--read-only` by default.
+- Enable write/command tools only for explicit implementation tasks.
+- Keep servers local-first and least-privilege.
+
+## Recommended command
+```bash
+pnpm exec ng mcp --read-only
+```
+
+## Optional command flags
+- `--read-only`: disables write and shell tools.
+- `--local-only`: disables web search tools.
+- `--experimental-tools`: enables Angular migration, docs search, and package info tools.
+
+## VS Code example (`.vscode/mcp.json`)
+```json
+{
+  "servers": {
+    "angular-cli": {
+      "type": "stdio",
+      "command": "pnpm",
+      "args": ["exec", "ng", "mcp", "--read-only"]
+    }
+  }
+}
+```
+
+## Cursor example (`.cursor/mcp.json`)
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "pnpm",
+      "args": ["exec", "ng", "mcp", "--read-only"]
+    }
+  }
+}
+```
+
+## Escalation modes
+1. Safe review mode:
+   - `pnpm exec ng mcp --read-only --local-only`
+2. Delivery mode (trusted prompt + active implementation):
+   - `pnpm exec ng mcp --experimental-tools`
+3. Controlled delivery mode:
+   - `pnpm exec ng mcp --experimental-tools --read-only`
+
+## Security checklist
+- Verify server origin and transport security.
+- Require explicit consent for destructive or sensitive actions.
+- Never pass through API keys or tokens without strict control.
+- Limit tool scope to the minimum required for the task.
+- Prefer local context (`AGENTS.md`, runbooks, architecture docs) before web pull.
+
+## Troubleshooting
+- `ng: command not found`:
+  - Run `pnpm install` and retry `pnpm exec ng mcp --read-only`.
+- MCP server not discovered in IDE:
+  - Check JSON format and working directory in IDE MCP settings.
+- Unexpected tool behavior:
+  - Restart IDE MCP session and force `--read-only` until verified.
+
+## Related docs
+- `docs/ai/angular-ai-professional-playbook.md`
+- `docs/runbooks/angular-frontend-architecture.md`
+- `docs/ai/agent-operating-model.md`

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -80,6 +80,8 @@ Notas operativas:
 - Modelo operativo de agentes: ver `docs/ai/agent-operating-model.md`.
 - Workflows repetibles del agente: ver `docs/ai/workflows/`.
 - Prompt templates reutilizables: ver `docs/ai/prompts/`.
+- Playbook Angular + IA: ver `docs/ai/angular-ai-professional-playbook.md`.
+- Setup MCP Angular CLI: ver `docs/runbooks/angular-mcp-setup.md`.
 - Setup de Supabase para BE-14: ver `docs/runbooks/supabase-setup.md`.
 - Decision tecnica local-first (GitHub Projects + Codex): ver `docs/adr/0003-github-project-local-first.md`.
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,33 @@
+# ia-pm-development - LLM Context Index
+
+> Primary rules and architecture context for AI assistants working in this repository.
+
+## Core governance
+- AGENTS.md
+- docs/ai/agent-operating-model.md
+- docs/runbooks/github-project-workflow.md
+- docs/runbooks/git-branching-model.md
+
+## Angular architecture and AI standards
+- docs/runbooks/angular-frontend-architecture.md
+- docs/ai/angular-ai-professional-playbook.md
+- docs/runbooks/angular-mcp-setup.md
+
+## Prompt templates
+- docs/ai/prompts/feature-spec-prompt.md
+- docs/ai/prompts/refactor-prompt.md
+- docs/ai/prompts/audit-prompt.md
+- docs/ai/prompts/frontend-feature-signals-prompt.md
+- docs/ai/prompts/frontend-refactor-signals-prompt.md
+- docs/ai/prompts/frontend-audit-signals-prompt.md
+
+## Frontend code map
+- apps/web/src/app/core/
+- apps/web/src/app/shared/
+- apps/web/src/app/features/auth/
+- apps/web/src/app/features/products/
+
+## Required validation
+- pnpm lint
+- pnpm test
+- pnpm build


### PR DESCRIPTION
## Summary\n- agrega playbook profesional de Angular + IA con arquitectura feature-first, estandar de stores @ngrx/signals, y contratos de entrega\n- agrega runbook MCP con configuracion recomendada --read-only, modos de escalamiento y checklist de seguridad\n- versiona archivos de instrucciones para asistentes (Copilot, VS Code, Cursor) y un llms.txt para contexto rapido\n- agrega prompts frontend especializados para feature/refactor/audit con enfoque signals\n- actualiza AGENTS y runbooks para referenciar los nuevos artefactos\n\n## Validation\n- pnpm lint\n- pnpm test\n- pnpm build\n\nCloses #39