### PR TITLE
fix(web): arreglar submit real de búsqueda en products

### DIFF
--- a/apps/web/src/app/features/products/ui/components/products-search-form.component.spec.ts
+++ b/apps/web/src/app/features/products/ui/components/products-search-form.component.spec.ts
@@ -19,15 +19,19 @@ describe('ProductsSearchFormComponent', () => {
 
   it('emits search event on submit', () => {
     const fixture = TestBed.createComponent(ProductsSearchFormComponent);
+    fixture.detectChanges();
     const component = fixture.componentInstance;
     let emitted = false;
+    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
 
     component.searchRequested.subscribe(() => {
       emitted = true;
     });
-    component.submitSearch();
+    form.dispatchEvent(submitEvent);
 
     expect(emitted).toBe(true);
+    expect(submitEvent.defaultPrevented).toBe(true);
   });
 
   it('shows loading label and disables submit while loading', () => {

--- a/apps/web/src/app/features/products/ui/components/products-search-form.component.ts
+++ b/apps/web/src/app/features/products/ui/components/products-search-form.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, input, output } from '@angular/core
 @Component({
   selector: 'app-products-search-form',
   template: `
-    <form class="flex flex-wrap gap-3" (ngSubmit)="submitSearch()" novalidate>
+    <form class="flex flex-wrap gap-3" (submit)="onSubmit($event)" novalidate>
       <label class="sr-only" for="products-query">Buscar productos</label>
       <input
         id="products-query"
@@ -42,7 +42,8 @@ export class ProductsSearchFormComponent {
     this.queryChange.emit(target.value);
   }
 
-  submitSearch(): void {
+  onSubmit(event: Event): void {
+    event.preventDefault();
     this.searchRequested.emit();
   }
 }

--- a/apps/web/src/app/features/products/ui/pages/products.page.spec.ts
+++ b/apps/web/src/app/features/products/ui/pages/products.page.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { provideRouter, Router } from '@angular/router';
 import { AuthStore } from '../../../auth/state/auth.store';
 import { ProductsStore } from '../../state/products.store';
+import { ProductsSearchFormComponent } from '../components/products-search-form.component';
 import { ProductsPageComponent } from './products.page';
 
 describe('ProductsPageComponent', () => {
@@ -129,5 +131,23 @@ describe('ProductsPageComponent', () => {
 
     const html = fixture.nativeElement as HTMLElement;
     expect(html.textContent).toContain('No hay productos');
+  });
+
+  it('requests products with current query when search form emits submit', async () => {
+    const fixture = TestBed.createComponent(ProductsPageComponent);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const searchFormDebug = fixture.debugElement.query(
+      By.directive(ProductsSearchFormComponent),
+    );
+    const searchForm = searchFormDebug.componentInstance as ProductsSearchFormComponent;
+
+    searchForm.queryChange.emit('lllll');
+    searchForm.searchRequested.emit();
+    fixture.detectChanges();
+
+    expect(loadProductsCalls).toEqual(['', 'lllll']);
   });
 });


### PR DESCRIPTION
## Summary
- corrige el formulario de búsqueda para usar evento nativo `submit` en lugar de `ngSubmit` (sin FormsModule)
- previene el submit nativo del navegador y emite `searchRequested` de forma consistente
- agrega prueba de interacción real del formulario (`dispatch submit`) para validar click/enter
- agrega prueba de contenedor para asegurar que el query actual (`lllll`) se envía al store al buscar

## Validation
- pnpm lint
- pnpm test
- pnpm build

Closes #48