### PR TITLE
chore(release): add AI self-review gate to PR and CI

### DIFF
--- a/.cursor/rules/angular-web.mdc
+++ b/.cursor/rules/angular-web.mdc
@@ -34,6 +34,7 @@ alwaysApply: false
 ## Delivery
 - Stay within issue scope.
 - Preserve `1 issue = 1 branch = 1 PR`.
+- Complete `AI Self-Review Gate` before PR review (`docs/ai/checklists/ai-self-review-gate.md`).
 - Final validation must include:
   - `pnpm lint`
   - `pnpm test`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@
 - Require linked issue with exactly one `agent:*` label.
 - Keep `1 issue = 1 branch = 1 PR`.
 - Include `Closes #<issue_number>` in PR body.
+- Complete `AI Self-Review Gate` in PR body using `docs/ai/checklists/ai-self-review-gate.md`.
 - Validate and report:
   - `pnpm lint`
   - `pnpm test`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,20 @@
 - [ ] `pnpm test`
 - [ ] `pnpm build`
 
+## AI Self-Review Gate
+### Framework reviewed
+- [ ] Angular way
+- [ ] NestJS way
+
+### Checklist
+- [ ] I reviewed `docs/ai/checklists/ai-self-review-gate.md`
+- [ ] Solution follows framework patterns and project rules
+
+### Decision
+Decision: `Compliant | Needs Changes`
+
+### Notes
+-
+
 ## Risks / Notes
 -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,26 @@ jobs:
               }
             }
 
+            const hasSelfReviewSection = /##\s+AI Self-Review Gate/i.test(body);
+            if (!hasSelfReviewSection) {
+              core.setFailed('PR must include the "AI Self-Review Gate" section.');
+            }
+
+            const angularChecked = /-\s*\[[xX]\]\s*Angular way/i.test(body);
+            const nestChecked = /-\s*\[[xX]\]\s*NestJS way/i.test(body);
+            if (!angularChecked && !nestChecked) {
+              core.setFailed(
+                'AI Self-Review Gate must mark at least one framework: "Angular way" or "NestJS way".',
+              );
+            }
+
+            const hasDecision = /Decision:\s*`?(Compliant|Needs Changes)`?/i.test(body);
+            if (!hasDecision) {
+              core.setFailed(
+                'AI Self-Review Gate must include "Decision: Compliant" or "Decision: Needs Changes".',
+              );
+            }
+
       - name: Validate Angular feature-first layer structure
         run: |
           FEATURES_ROOT="apps/web/src/app/features"
@@ -116,6 +136,7 @@ jobs:
             ".instructions.md"
             ".cursor/rules/angular-web.mdc"
             "docs/ai/angular-ai-professional-playbook.md"
+            "docs/ai/checklists/ai-self-review-gate.md"
             "docs/runbooks/angular-mcp-setup.md"
           )
 

--- a/.instructions.md
+++ b/.instructions.md
@@ -17,6 +17,9 @@
 - `pnpm lint`
 - `pnpm test`
 - `pnpm build`
+- Complete final self-review gate:
+  - `docs/ai/checklists/ai-self-review-gate.md`
+  - PR section `AI Self-Review Gate` with framework + decision
 
 ## Reference docs
 - `AGENTS.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Operate as a professional software delivery agent for a monorepo with:
 - Git strategy: `docs/runbooks/git-branching-model.md`
 - Operating model: `docs/ai/agent-operating-model.md`
 - Angular + AI playbook: `docs/ai/angular-ai-professional-playbook.md`
+- AI self-review gate: `docs/ai/checklists/ai-self-review-gate.md`
 - Backlog conventions: `docs/planning/github-project-backlog.md`
 - Local operation: `docs/runbooks/local-dev.md`
 - MCP setup: `docs/runbooks/angular-mcp-setup.md`

--- a/docs/ai/agent-operating-model.md
+++ b/docs/ai/agent-operating-model.md
@@ -41,9 +41,10 @@ Los labels `agent:*` siguen siendo obligatorios para ownership y trazabilidad, a
 2. PM mueve card a `Todo`.
 3. Agente owner mueve card a `In Progress`, crea rama y ejecuta implementacion.
 4. Agente owner valida `pnpm lint`, `pnpm test`, `pnpm build`.
-5. Agente owner abre PR con `Closes #<issue_number>` y mueve issue a `In Review`.
-6. Reviewer/QA valida cumplimiento funcional y calidad.
-7. Con merge a `main`, issue pasa a `Done`.
+5. Agente owner ejecuta self-review final con `docs/ai/checklists/ai-self-review-gate.md`.
+6. Agente owner abre PR con `Closes #<issue_number>` y seccion `AI Self-Review Gate`; luego mueve issue a `In Review`.
+7. Reviewer/QA valida cumplimiento funcional y calidad.
+8. Con merge a `main`, issue pasa a `Done`.
 
 ## Definition of done por agente
 ### `agent:pm`

--- a/docs/ai/angular-ai-professional-playbook.md
+++ b/docs/ai/angular-ai-professional-playbook.md
@@ -115,6 +115,16 @@ apps/web/src/app
    - `pnpm lint`
    - `pnpm test`
    - `pnpm build`
+5. PR includes completed `AI Self-Review Gate` section.
+
+## Mandatory AI self-review gate
+- Final technical step before opening PR or moving issue to `In Review`.
+- Use `docs/ai/checklists/ai-self-review-gate.md`.
+- Mark framework reviewed (`Angular way` and/or `NestJS way`).
+- Record decision in PR body:
+  - `Compliant`
+  - `Needs Changes`
+- If decision is `Needs Changes`, fix first and only then request review.
 
 ## Testing baseline
 - Unit/component: Angular unit tests and store tests in feature scope.

--- a/docs/ai/checklists/ai-self-review-gate.md
+++ b/docs/ai/checklists/ai-self-review-gate.md
@@ -1,0 +1,47 @@
+# AI Self-Review Gate (Angular way / NestJS way)
+
+## Objetivo
+Agregar una verificacion final obligatoria antes de cerrar una implementacion para confirmar que la solucion sigue el framework correcto (`Angular way` o `NestJS way`) y las reglas del proyecto.
+
+## Cuando aplicar este gate
+Aplicar siempre en el ultimo paso tecnico, antes de abrir PR o de mover la issue a `In Review`.
+
+## Seleccion de framework
+- Marca `Angular way` si hubo cambios en `apps/web` o en docs/arquitectura frontend.
+- Marca `NestJS way` si hubo cambios en `apps/api` o en contratos backend.
+- Si hubo cambios en ambos, ejecutar y evidenciar ambos checklists.
+
+## Checklist global (siempre)
+- [ ] Scope implementado coincide con criterios de aceptacion de la issue.
+- [ ] Se mantiene `1 issue = 1 branch = 1 PR`.
+- [ ] PR incluye `Closes #<issue_number>`.
+- [ ] Se ejecutaron y pasaron:
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm build`
+- [ ] Riesgos residuales y limitaciones quedaron documentados.
+
+## Checklist Angular way
+- [ ] Arquitectura feature-first respetada (`domain`, `data-access`, `state`, `ui`).
+- [ ] Limites de capas respetados (`ui -> state -> data-access`).
+- [ ] Estado de feature estandarizado con `@ngrx/signals`.
+- [ ] Componentes mantienen enfoque presentacional o contenedor sin acoplamientos indebidos.
+- [ ] Templates usan control flow nativo (`@if`, `@for`, `@switch`) cuando aplica.
+- [ ] Estados UX cubiertos (loading, empty, error, success).
+- [ ] Accesibilidad base validada (focus, labels, feedback de error, contraste AA).
+
+## Checklist NestJS way
+- [ ] Separacion clara por capas (controller/service/repository o equivalente).
+- [ ] DTOs y validaciones consistentes (pipes, class-validator, contrato de entrada/salida).
+- [ ] Manejo de errores y codigos HTTP consistente.
+- [ ] Autenticacion/autorizacion revisada (guards, roles, claims) cuando aplica.
+- [ ] No se filtran detalles de infraestructura en contratos publicos.
+- [ ] Tests actualizados para caminos felices y de error.
+
+## Evidencia obligatoria en PR
+Completar seccion `AI Self-Review Gate` del PR template:
+- Framework aplicable marcado (`Angular way` y/o `NestJS way`).
+- Decision final:
+  - `Compliant`: cumple framework + reglas de proyecto.
+  - `Needs Changes`: requiere ajustes antes de merge.
+- Notas cortas con criterios revisados y riesgos residuales.

--- a/docs/ai/prompts/audit-prompt.md
+++ b/docs/ai/prompts/audit-prompt.md
@@ -17,7 +17,8 @@ Instrucciones:
 4) Diferencia entre bloqueo vs recomendación.
 5) Evalúa cobertura de acceptance criteria y DoD del agente owner.
 6) Evalúa si lint/test/build son evidencia suficiente.
-7) Termina con veredicto: approve o changes requested.
+7) Verifica consistencia del `AI Self-Review Gate` contra el código real.
+8) Termina con veredicto: approve o changes requested.
 
 Responde en español, concreto y accionable.
 ```

--- a/docs/ai/prompts/feature-spec-prompt.md
+++ b/docs/ai/prompts/feature-spec-prompt.md
@@ -17,6 +17,7 @@ Necesito que generes una especificación ejecutable con:
 6) Riesgos y mitigaciones.
 7) Plan de pruebas mínimo (unit/integration/e2e si aplica).
 8) Definition of done.
+9) Criterios del `AI Self-Review Gate` antes de PR (`docs/ai/checklists/ai-self-review-gate.md`).
 
 Responde en español y alineado al modelo agent-first del repo.
 ```

--- a/docs/ai/prompts/frontend-audit-signals-prompt.md
+++ b/docs/ai/prompts/frontend-audit-signals-prompt.md
@@ -31,7 +31,8 @@ Instrucciones:
    - pnpm lint
    - pnpm test
    - pnpm build
-6) Cierra con veredicto:
+6) Verifica que el `AI Self-Review Gate` del PR sea consistente con los cambios.
+7) Cierra con veredicto:
    - approved
    - changes requested
 

--- a/docs/ai/prompts/frontend-feature-signals-prompt.md
+++ b/docs/ai/prompts/frontend-feature-signals-prompt.md
@@ -28,6 +28,8 @@ Requirements:
    - pnpm lint
    - pnpm test
    - pnpm build
+9) Complete and report `AI Self-Review Gate` from:
+   - docs/ai/checklists/ai-self-review-gate.md
 
 Constraints:
 - Keep PR scoped to issue acceptance criteria.

--- a/docs/ai/prompts/frontend-refactor-signals-prompt.md
+++ b/docs/ai/prompts/frontend-refactor-signals-prompt.md
@@ -24,6 +24,8 @@ Entrega requerida:
    - pnpm lint
    - pnpm test
    - pnpm build
+8) Cierre obligatorio con `AI Self-Review Gate`:
+   - docs/ai/checklists/ai-self-review-gate.md
 
 Reglas:
 - Mantener 1 issue = 1 branch = 1 PR.

--- a/docs/ai/prompts/refactor-prompt.md
+++ b/docs/ai/prompts/refactor-prompt.md
@@ -17,6 +17,7 @@ Entrega requerida:
 4) Riesgos por paso.
 5) Pruebas necesarias para asegurar no regresión.
 6) Señales de stop (cuándo pausar y re-planificar).
+7) Checklist de cierre con `AI Self-Review Gate` (`docs/ai/checklists/ai-self-review-gate.md`).
 
 No implementes todo de golpe; propone secuencia segura y verificable.
 ```

--- a/docs/ai/workflows/deploy.md
+++ b/docs/ai/workflows/deploy.md
@@ -13,6 +13,7 @@ description: Execute release and deploy checks for web and API with evidence and
 1. Confirm linked issue scope and acceptance criteria.
 2. Confirm CI green on target branch.
 3. Confirm required environment variables are defined for target service.
+4. Confirm PR has completed `AI Self-Review Gate` with applicable framework.
 
 ## Step 2: Pre-deploy Verification
 1. Run local gates:

--- a/docs/ai/workflows/new-feature.md
+++ b/docs/ai/workflows/new-feature.md
@@ -40,10 +40,14 @@ description: Deliver a new feature using the agent-first model with issue-to-PR 
    - `pnpm test`
    - `pnpm build`
 2. If failures appear, fix before opening PR.
+3. Execute final self-review gate:
+   - Use `docs/ai/checklists/ai-self-review-gate.md`.
+   - Validate `Angular way` and/or `NestJS way` according to changed scope.
 
 ## Step 5: Deliver
 1. Open PR with:
    - `Closes #<issue_number>`
+   - `AI Self-Review Gate` section completed with framework and decision
    - Summary of what changed
    - Validation evidence
    - Residual risks

--- a/docs/ai/workflows/review-pr.md
+++ b/docs/ai/workflows/review-pr.md
@@ -12,6 +12,7 @@ description: Review a pull request against issue scope, agent ownership, and qua
 1. Read PR description and linked issue.
 2. Confirm PR includes `Closes #<issue_number>`.
 3. Confirm issue has exactly one `agent:*` label.
+4. Confirm PR includes `AI Self-Review Gate` with framework marked and decision.
 
 ## Step 2: Scope Validation
 1. Compare issue acceptance criteria vs implemented behavior.
@@ -27,6 +28,7 @@ description: Review a pull request against issue scope, agent ownership, and qua
 1. Verify `pnpm lint`, `pnpm test`, `pnpm build` status.
 2. Verify CI `quality` check is passing.
 3. Check for release-impacting risk when workflow or runtime config changed.
+4. Cross-check self-review claims against actual code changes.
 
 ## Step 5: Decision
 1. Approve when criteria and quality gates are satisfied.

--- a/docs/runbooks/github-pr-flow.md
+++ b/docs/runbooks/github-pr-flow.md
@@ -56,6 +56,9 @@ El job `quality` en `.github/workflows/ci.yml` valida adicionalmente:
 - PR body con `Closes #<issue_number>` exacto.
 - Exactamente 1 issue de cierre por PR.
 - Issue de cierre abierta y con exactamente 1 label `agent:*`.
+- Seccion `AI Self-Review Gate` presente en PR body.
+- Framework marcado en self-review (`Angular way` o `NestJS way`).
+- Decision de self-review (`Compliant` o `Needs Changes`).
 - Convencion de ramas (`feature/*`, `fix/*`, `chore/*`).
 - Estructura frontend feature-first por capas (`domain`, `data-access`, `state`, `ui`).
 - Presencia de archivos de contexto IA requeridos:
@@ -65,6 +68,7 @@ El job `quality` en `.github/workflows/ci.yml` valida adicionalmente:
   - `.instructions.md`
   - `.cursor/rules/angular-web.mdc`
   - `docs/ai/angular-ai-professional-playbook.md`
+  - `docs/ai/checklists/ai-self-review-gate.md`
   - `docs/runbooks/angular-mcp-setup.md`
 
 ## 6) Troubleshooting rapido
@@ -72,6 +76,9 @@ El job `quality` en `.github/workflows/ci.yml` valida adicionalmente:
   - Agregar la linea exacta en el cuerpo del PR y re-ejecutar checks.
 - Falla por ownership `agent:*`:
   - Ajustar labels de la issue para dejar exactamente un `agent:*`.
+- Falla por `AI Self-Review Gate`:
+  - Completar seccion del PR template usando `docs/ai/checklists/ai-self-review-gate.md`.
+  - Marcar framework aplicable y definir `Decision: Compliant` o `Decision: Needs Changes`.
 - Falla por estructura feature-first:
   - Revisar `apps/web/src/app/features/<feature>` y crear capas faltantes.
 - Falla por archivos IA faltantes:

--- a/docs/runbooks/github-project-workflow.md
+++ b/docs/runbooks/github-project-workflow.md
@@ -26,17 +26,18 @@ Sin ese label, la tarea se considera mal definida y no entra a ejecucion.
 4. Agente owner toma la issue y la mueve a `In Progress`.
 5. Agente owner crea rama (`feature/<slug>` o `fix/<slug>`) y ejecuta implementacion acotada al scope.
 6. Agente owner ejecuta calidad local: `pnpm lint`, `pnpm test`, `pnpm build`.
-7. Agente owner abre PR con `Closes #<issue_number>`.
-8. Agente owner mueve la issue a `In Review`.
-9. QA/Reviewer valida criterios de aceptacion y evidencia tecnica.
-10. Al merge, la issue pasa a `Done`.
+7. Agente owner ejecuta self-review final con `docs/ai/checklists/ai-self-review-gate.md`.
+8. Agente owner abre PR con `Closes #<issue_number>` y seccion `AI Self-Review Gate`.
+9. Agente owner mueve la issue a `In Review`.
+10. QA/Reviewer valida criterios de aceptacion y evidencia tecnica.
+11. Al merge, la issue pasa a `Done`.
 
 ## Reglas operativas
 - 1 issue = 1 rama = 1 PR.
 - PR pequena y trazable.
 - No expandir scope fuera de criterios de aceptacion.
 - CI debe pasar antes de merge.
-- El check `quality` valida convencion de rama y issue enlazada con label `agent:*`.
+- El check `quality` valida convencion de rama, issue enlazada con label `agent:*` y `AI Self-Review Gate` en PR.
 
 ## Operacion diaria con CLI
 ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -5,6 +5,7 @@
 ## Core governance
 - AGENTS.md
 - docs/ai/agent-operating-model.md
+- docs/ai/checklists/ai-self-review-gate.md
 - docs/runbooks/github-project-workflow.md
 - docs/runbooks/git-branching-model.md
 


### PR DESCRIPTION
## Linked Issue
Closes #51

## Scope
- Define and version a mandatory AI self-review checklist (Angular way / NestJS way).
- Integrate the gate into workflows, PR template, and CI quality guardrails.
- Update project AI context docs so agents apply the gate consistently.

## Changes
- Added `docs/ai/checklists/ai-self-review-gate.md`.
- Updated `.github/pull_request_template.md` with required `AI Self-Review Gate` section.
- Updated `.github/workflows/ci.yml` to fail when self-review section/framework/decision are missing.
- Updated operating/workflow/runbook docs to include the mandatory final self-review step.
- Updated AI instruction/context files (`AGENTS.md`, `.instructions.md`, `.github/copilot-instructions.md`, `.cursor/rules/angular-web.mdc`, `llms.txt`).

## Validation
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`

## AI Self-Review Gate
### Framework reviewed
- [x] Angular way
- [x] NestJS way

### Checklist
- [x] I reviewed `docs/ai/checklists/ai-self-review-gate.md`
- [x] Solution follows framework patterns and project rules

### Decision
Decision: Compliant

### Notes
- CI now enforces the self-review section and decision in every PR body.
- Workflows and runbooks include the gate before `In Review` / merge.

## Risks / Notes
- Existing open PRs created before this change may need body updates to pass the new guardrail.