### PR TITLE
test(web): validar flujo de detalle/edición para FE-02

### DIFF
--- a/apps/web/src/app/features/products/ui/pages/products.page.spec.ts
+++ b/apps/web/src/app/features/products/ui/pages/products.page.spec.ts
@@ -38,6 +38,7 @@ describe('ProductsPageComponent', () => {
   let clearErrorCalls: number;
   let clearSessionCalls: number;
   let createCalls: number;
+  let updateCalls: { productId: string; input: ProductMutationInput }[];
   let getProductCalls: string[];
   let deleteCalls: string[];
 
@@ -75,8 +76,7 @@ describe('ProductsPageComponent', () => {
       return of(baseProduct);
     },
     updateProduct(productId: string, input: ProductMutationInput) {
-      void productId;
-      void input;
+      updateCalls.push({ productId, input });
       return of(baseProduct);
     },
     deleteProduct(productId: string) {
@@ -90,6 +90,7 @@ describe('ProductsPageComponent', () => {
     clearErrorCalls = 0;
     clearSessionCalls = 0;
     createCalls = 0;
+    updateCalls = [];
     getProductCalls = [];
     deleteCalls = [];
     productsSignal.set([]);
@@ -209,5 +210,33 @@ describe('ProductsPageComponent', () => {
       value: originalConfirm,
       configurable: true,
     });
+  });
+
+  it('updates a product when edit form is submitted', async () => {
+    productsSignal.set([baseProduct]);
+    const fixture = TestBed.createComponent(ProductsPageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const component = fixture.componentInstance;
+    component.startEdit('prod-01');
+    await fixture.whenStable();
+
+    component.productForm.patchValue({
+      name: 'Producto actualizado',
+      quantity: 9,
+      unitPriceCents: 2590,
+      status: 'active',
+    });
+    component.saveProduct(new Event('submit'));
+    await fixture.whenStable();
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]).toEqual(
+      expect.objectContaining({
+        productId: 'prod-01',
+      }),
+    );
+    expect(loadProductsCalls).toEqual(['', '']);
   });
 });


### PR DESCRIPTION
## Linked Issue
- [x] PR description includes `Closes #<issue_number>`
- [x] PR links exactly one closing issue
- [x] Linked issue has exactly one `agent:*` label

Closes #9

## Scope
- [x] This PR implements only the issue scope and acceptance criteria
- [x] Issue status moved to `In Review` in GitHub Project

## Changes
- Added explicit UI test coverage for product edit flow in `ProductsPageComponent`.
- Validated that detail -> edit -> save triggers `updateProduct` with selected product id.
- Validated listing reload after successful edit save (`loadProducts` call).

## Validation
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`

## AI Self-Review Gate
### Framework reviewed
- [x] Angular way
- [ ] NestJS way

### Checklist
- [x] I reviewed `docs/ai/checklists/ai-self-review-gate.md`
- [x] Solution follows framework patterns and project rules

### Decision
Decision: `Compliant`

### Notes
- Feature behavior for detail/edit/delete is already present in current products page and this PR solidifies acceptance criteria with focused tests.

## Risks / Notes
- Low risk: test-only change in frontend spec.