### PR TITLE
feat(api): align health readiness with prisma (IA-27)

### DIFF
--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -32,7 +32,7 @@ export class HealthController {
   @HealthCheck()
   getReadiness() {
     return this.health.check([
-      () => this.healthService.getReadinessSupabase(),
+      () => this.healthService.getReadinessPrisma(),
       () => this.healthService.getReadinessMemory(),
     ]);
   }

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -3,12 +3,13 @@ import { TerminusModule } from '@nestjs/terminus';
 import { AuthModule } from '../auth/auth.module';
 import { IntegrationsModule } from '../integrations/integrations.module';
 import { HealthController } from './health.controller';
+import { PrismaHealthIndicator } from './indicators/prisma-health.indicator';
 import { SupabaseHealthIndicator } from './indicators/supabase-health.indicator';
 import { HealthService } from './health.service';
 
 @Module({
   imports: [TerminusModule, IntegrationsModule, AuthModule],
   controllers: [HealthController],
-  providers: [HealthService, SupabaseHealthIndicator],
+  providers: [HealthService, SupabaseHealthIndicator, PrismaHealthIndicator],
 })
 export class HealthModule {}

--- a/apps/api/src/health/health.service.spec.ts
+++ b/apps/api/src/health/health.service.spec.ts
@@ -1,5 +1,5 @@
 import { MemoryHealthIndicator } from '@nestjs/terminus';
-import { SupabaseHealthIndicator } from './indicators/supabase-health.indicator';
+import { PrismaHealthIndicator } from './indicators/prisma-health.indicator';
 import { HealthService } from './health.service';
 
 describe('HealthService', () => {
@@ -7,9 +7,9 @@ describe('HealthService', () => {
     const memoryHealthIndicator = {
       checkHeap: jest.fn(),
     } as unknown as MemoryHealthIndicator;
-    const supabaseHealthIndicator = {
+    const prismaHealthIndicator = {
       isHealthy: jest.fn(),
-    } as unknown as SupabaseHealthIndicator;
+    } as unknown as PrismaHealthIndicator;
 
     const service = new HealthService(
       {
@@ -31,7 +31,7 @@ describe('HealthService', () => {
         },
       },
       memoryHealthIndicator,
-      supabaseHealthIndicator,
+      prismaHealthIndicator,
     );
     const health = service.getLiveness();
 
@@ -49,11 +49,11 @@ describe('HealthService', () => {
       checkHeap: checkHeapMock,
     } as unknown as MemoryHealthIndicator;
     const isHealthyMock = jest.fn().mockResolvedValue({
-      supabase: { status: 'up', configured: true },
+      prisma: { status: 'up', configured: true },
     });
-    const supabaseHealthIndicator = {
+    const prismaHealthIndicator = {
       isHealthy: isHealthyMock,
-    } as unknown as SupabaseHealthIndicator;
+    } as unknown as PrismaHealthIndicator;
 
     const service = new HealthService(
       {
@@ -75,14 +75,14 @@ describe('HealthService', () => {
         },
       },
       memoryHealthIndicator,
-      supabaseHealthIndicator,
+      prismaHealthIndicator,
     );
-    const supabaseCheck = await service.getReadinessSupabase();
+    const prismaCheck = await service.getReadinessPrisma();
     const memoryCheck = await service.getReadinessMemory();
 
-    expect(supabaseCheck.supabase.status).toBe('up');
+    expect(prismaCheck.prisma.status).toBe('up');
     expect(memoryCheck.memory_heap.status).toBe('up');
-    expect(isHealthyMock).toHaveBeenCalledWith('supabase', {
+    expect(isHealthyMock).toHaveBeenCalledWith('prisma', {
       checkRead: true,
     });
     expect(checkHeapMock).toHaveBeenCalledWith(

--- a/apps/api/src/health/health.service.ts
+++ b/apps/api/src/health/health.service.ts
@@ -3,7 +3,7 @@ import type { ConfigType } from '@nestjs/config';
 import type { HealthIndicatorResult } from '@nestjs/terminus';
 import { MemoryHealthIndicator } from '@nestjs/terminus';
 import appConfig from '../config/app.config';
-import { SupabaseHealthIndicator } from './indicators/supabase-health.indicator';
+import { PrismaHealthIndicator } from './indicators/prisma-health.indicator';
 
 @Injectable()
 export class HealthService {
@@ -11,7 +11,7 @@ export class HealthService {
     @Inject(appConfig.KEY)
     private readonly appConfiguration: ConfigType<typeof appConfig>,
     private readonly memoryHealthIndicator: MemoryHealthIndicator,
-    private readonly supabaseHealthIndicator: SupabaseHealthIndicator,
+    private readonly prismaHealthIndicator: PrismaHealthIndicator,
   ) {}
 
   getLiveness(): HealthIndicatorResult<'application'> {
@@ -26,8 +26,8 @@ export class HealthService {
     };
   }
 
-  getReadinessSupabase(): Promise<HealthIndicatorResult<'supabase'>> {
-    return this.supabaseHealthIndicator.isHealthy('supabase', {
+  getReadinessPrisma(): Promise<HealthIndicatorResult<'prisma'>> {
+    return this.prismaHealthIndicator.isHealthy('prisma', {
       checkRead: true,
     });
   }

--- a/apps/api/src/health/indicators/prisma-health.indicator.spec.ts
+++ b/apps/api/src/health/indicators/prisma-health.indicator.spec.ts
@@ -1,0 +1,76 @@
+import { HealthIndicatorService } from '@nestjs/terminus';
+import type { PrismaService } from '../../integrations/prisma/prisma.service';
+import { PrismaHealthIndicator } from './prisma-health.indicator';
+
+describe('PrismaHealthIndicator', () => {
+  function createIndicator(
+    prismaService: PrismaService,
+    environment: 'development' | 'production' | 'test' = 'development',
+  ): PrismaHealthIndicator {
+    return new PrismaHealthIndicator(
+      prismaService,
+      new HealthIndicatorService(),
+      {
+        environment,
+      } as never,
+    );
+  }
+
+  it('reports up with fallback mode when prisma is not configured outside production', async () => {
+    const prismaService = {
+      isConfigured: () => false,
+      $queryRawUnsafe: jest.fn(),
+    } as unknown as PrismaService;
+    const indicator = createIndicator(prismaService, 'development');
+
+    const result = await indicator.isHealthy('prisma', { checkRead: true });
+
+    expect(result.prisma.status).toBe('up');
+    expect(result.prisma.configured).toBe(false);
+    expect(result.prisma.mode).toBe('in-memory-fallback');
+  });
+
+  it('reports down when prisma is not configured in production', async () => {
+    const prismaService = {
+      isConfigured: () => false,
+      $queryRawUnsafe: jest.fn(),
+    } as unknown as PrismaService;
+    const indicator = createIndicator(prismaService, 'production');
+
+    const result = await indicator.isHealthy('prisma', { checkRead: true });
+
+    expect(result.prisma.status).toBe('down');
+    expect(result.prisma.configured).toBe(false);
+    expect(result.prisma.reason).toContain('DATABASE_URL');
+  });
+
+  it('reports up when configured and query succeeds', async () => {
+    const queryMock = jest.fn().mockResolvedValue([{ '?column?': 1 }]);
+    const prismaService = {
+      isConfigured: () => true,
+      $queryRawUnsafe: queryMock,
+    } as unknown as PrismaService;
+    const indicator = createIndicator(prismaService, 'production');
+
+    const result = await indicator.isHealthy('prisma', { checkRead: true });
+
+    expect(result.prisma.status).toBe('up');
+    expect(result.prisma.configured).toBe(true);
+    expect(result.prisma.reachable).toBe(true);
+    expect(queryMock).toHaveBeenCalledWith('SELECT 1');
+  });
+
+  it('reports down when configured but query fails', async () => {
+    const prismaService = {
+      isConfigured: () => true,
+      $queryRawUnsafe: jest.fn().mockRejectedValue(new Error('db offline')),
+    } as unknown as PrismaService;
+    const indicator = createIndicator(prismaService, 'production');
+
+    const result = await indicator.isHealthy('prisma', { checkRead: true });
+
+    expect(result.prisma.status).toBe('down');
+    expect(result.prisma.configured).toBe(true);
+    expect(result.prisma.reachable).toBe(false);
+  });
+});

--- a/apps/api/src/health/indicators/prisma-health.indicator.ts
+++ b/apps/api/src/health/indicators/prisma-health.indicator.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { ConfigType } from '@nestjs/config';
+import {
+  HealthIndicatorService,
+  type HealthIndicatorResult,
+} from '@nestjs/terminus';
+import appConfig from '../../config/app.config';
+import { PrismaService } from '../../integrations/prisma/prisma.service';
+
+@Injectable()
+export class PrismaHealthIndicator {
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly healthIndicatorService: HealthIndicatorService,
+    @Inject(appConfig.KEY)
+    private readonly appConfiguration: ConfigType<typeof appConfig>,
+  ) {}
+
+  async isHealthy(
+    key: string,
+    options?: { checkRead?: boolean },
+  ): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+    const checkRead = options?.checkRead ?? true;
+
+    if (!this.prismaService.isConfigured()) {
+      if (this.appConfiguration.environment === 'production') {
+        return indicator.down({
+          configured: false,
+          reachable: false,
+          reason: 'DATABASE_URL is missing in production',
+        });
+      }
+
+      return indicator.up({
+        configured: false,
+        reachable: false,
+        mode: 'in-memory-fallback',
+      });
+    }
+
+    if (!checkRead) {
+      return indicator.up({ configured: true });
+    }
+
+    try {
+      await this.prismaService.$queryRawUnsafe('SELECT 1');
+
+      return indicator.up({ configured: true, reachable: true });
+    } catch {
+      return indicator.down({ configured: true, reachable: false });
+    }
+  }
+}

--- a/docs/runbooks/prisma-rollout-recovery.md
+++ b/docs/runbooks/prisma-rollout-recovery.md
@@ -60,6 +60,18 @@ Expected:
 - HTTP `200`
 - response contains `"application": { "status": "up" }`
 
+### API readiness (admin token required)
+```bash
+TOKEN="<jwt-with-admin-role>"
+curl -fsS "$API_BASE_URL/v1/health/ready" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Expected:
+- HTTP `200`
+- response contains `"prisma": { "status": "up" }`
+- response contains `"memory_heap": { "status": "up" }`
+
 ### Auth flow
 ```bash
 curl -fsS -X POST "$API_BASE_URL/v1/auth/register" \
@@ -119,6 +131,3 @@ git pull --ff-only origin main
 git revert <merge-sha>
 git push origin main
 ```
-
-## Known residual risk
-`/v1/health/ready` still checks Supabase + memory and does not yet include Prisma readiness; track and resolve via `IA-27`.


### PR DESCRIPTION
Linear: IA-27
Agent Owner: agent:backend
Notion: https://www.notion.so/30cf5efd90da815f8120c23e7171bd5b

## Linked Work Item
- [x] PR description includes the Linear issue reference
- [x] PR links exactly one Linear issue
- [x] Linked Linear issue has exactly one gent:* label

## Scope
- [x] This PR implements only the issue scope and acceptance criteria
- [ ] Issue status moved to In Review in Linear
- [x] Notion documentation link added to the Linear issue

## Changes
- Added PrismaHealthIndicator with production-safe behavior for unconfigured/degraded Prisma
- Replaced readiness persistence check from Supabase to Prisma in HealthService and HealthController
- Registered Prisma indicator in HealthModule
- Added unit test suite for Prisma health indicator scenarios
- Updated release runbook smoke checks to include /v1/health/ready Prisma verification

## Validation
- [x] pnpm lint
- [x] pnpm test
- [x] pnpm build

## AI Self-Review Gate
### Framework reviewed
- [ ] Angular way
- [x] NestJS way

### Checklist
- [x] I reviewed docs/ai/checklists/ai-self-review-gate.md
- [x] Solution follows framework patterns and project rules

### Decision
Decision: Compliant

### Notes
- Readiness now reflects Prisma state when Prisma is active persistence.

## Risks / Notes
- Existing Supabase indicator remains in codebase but is no longer part of /v1/health/ready.